### PR TITLE
fix(t3code): prepend explicit cd to interactive shell build commands

### DIFF
--- a/idx0/Apps/T3Code/T3CodeRuntime.swift
+++ b/idx0/Apps/T3Code/T3CodeRuntime.swift
@@ -311,14 +311,14 @@ final class T3BuildCoordinator {
 
         try await runChecked(
             executable: "/bin/zsh",
-            arguments: ["-ilc", manifest.installCommand],
+            arguments: ["-ilc", interactiveShellCommand(manifest.installCommand, workingDirectory: paths.sourceDirectory.path)],
             currentDirectory: paths.sourceDirectory.path,
             paths: paths
         )
 
         try await runChecked(
             executable: "/bin/zsh",
-            arguments: ["-ilc", manifest.buildCommand],
+            arguments: ["-ilc", interactiveShellCommand(manifest.buildCommand, workingDirectory: paths.sourceDirectory.path)],
             currentDirectory: paths.sourceDirectory.path,
             paths: paths
         )
@@ -332,7 +332,7 @@ final class T3BuildCoordinator {
                 appendBuildLog(paths: paths, line: "Client bundle missing after build; running canonical full build")
                 try await runChecked(
                     executable: "/bin/zsh",
-                    arguments: ["-ilc", T3BuildManifest.canonicalBuildCommand],
+                    arguments: ["-ilc", interactiveShellCommand(T3BuildManifest.canonicalBuildCommand, workingDirectory: paths.sourceDirectory.path)],
                     currentDirectory: paths.sourceDirectory.path,
                     paths: paths
                 )
@@ -402,6 +402,22 @@ final class T3BuildCoordinator {
             .filter { !$0.isEmpty }
 
         return candidates.first(where: { $0.hasPrefix("/") })
+    }
+
+    private func interactiveShellCommand(_ command: String, workingDirectory: String) -> String {
+        "builtin cd -- \(shellEscape(workingDirectory)) && \(command)"
+    }
+
+    private func shellEscape(_ value: String) -> String {
+        guard !value.isEmpty else { return "''" }
+
+        let safeCharacters = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_@%+=:,./-")
+        if value.rangeOfCharacter(from: safeCharacters.inverted) == nil {
+            return value
+        }
+
+        let escaped = value.replacingOccurrences(of: "'", with: "'\"'\"'")
+        return "'\(escaped)'"
     }
 
     private func runChecked(


### PR DESCRIPTION
## Problem and user impact

Interactive zsh sessions launched with `-ilc` may start in a different working directory depending on the user's shell startup scripts (e.g. `~/.zshrc` or `~/.zprofile` running a `cd` or `z`/`zoxide` command). This causes `install`, `build`, and canonical-build commands in `T3BuildCoordinator` to silently run from the wrong directory, producing cryptic build failures or incorrect output.

## Change

Introduces two small private helpers on `T3BuildCoordinator`:

- `interactiveShellCommand(_:workingDirectory:)` — prepends `builtin cd -- <path> &&` to any shell command.
- `shellEscape(_:)` — single-quote-escapes a path for safe shell interpolation.

All three `runChecked` call-sites (install, build, canonical build) now wrap their commands through `interactiveShellCommand`, guaranteeing the working directory is correct even when shell init scripts alter it.

## Scope

Touches only `idx0/Apps/T3Code/T3CodeRuntime.swift`. No architecture, IPC, persistence, or command-surface changes.

## Local verification

```bash
# maintainability gate
./scripts/maintainability-gate.sh

# targeted test run
xcodebuild -project idx0.xcodeproj -scheme idx0 \
  -destination 'platform=macOS' \
  -only-testing:idx0Tests/T3CodeRuntimeTests test

# full test suite
xcodebuild -project idx0.xcodeproj -scheme idx0 \
  -destination 'platform=macOS' test
```

## Risks and follow-ups

- `shellEscape` covers the POSIX single-quote escape convention; no known edge cases for typical macOS project paths.
- No follow-up work required. If future commands are added to `T3BuildCoordinator`, they should route through `interactiveShellCommand` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)