### PR TITLE
feat: harden manual release automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Protocol reference:
 - [docs/contribution-guide.md](docs/contribution-guide.md)
 - [docs/style-guide.md](docs/style-guide.md)
 - [docs/testing-guide.md](docs/testing-guide.md)
+- [docs/release-runbook.md](docs/release-runbook.md)
 - [docs/architecture/deep-dive.md](docs/architecture/deep-dive.md)
 
 ## Quality Gates

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # idx0 Documentation Hub
 
-Last updated: 2026-03-22
+Last updated: 2026-03-25
 
 This folder is the contributor handbook for `idx0`, a native macOS session-first terminal app built with SwiftUI + AppKit + libghostty.
 
@@ -10,6 +10,7 @@ This folder is the contributor handbook for `idx0`, a native macOS session-first
 - Feature or refactor work: read [Architecture Deep Dive](architecture/deep-dive.md) and [Runtime Integrations](architecture/runtime-integrations.md).
 - Data/model changes: read [Persistence and State](architecture/persistence-and-state.md).
 - Release hardening and incidents: use [Operations Playbook](operations-playbook.md).
+- Publishing a version: follow [Release Runbook](release-runbook.md).
 
 ## Repository Snapshot (2026-03-22)
 
@@ -27,6 +28,7 @@ This folder is the contributor handbook for `idx0`, a native macOS session-first
 - [Style Guide](style-guide.md)
 - [Testing Guide](testing-guide.md)
 - [Operations Playbook](operations-playbook.md)
+- [Release Runbook](release-runbook.md)
 
 ### Architecture Guides
 

--- a/docs/operations-playbook.md
+++ b/docs/operations-playbook.md
@@ -102,6 +102,8 @@ Mitigation:
 
 ## 4. Release/Pre-Merge Checklist
 
+For the full command-by-command release flow, use [Release Runbook](release-runbook.md).
+
 - [ ] Build and test pass on target macOS dev environment.
 - [ ] Maintainability gate reviewed.
 - [ ] Coverage gate attempted (or blocked reason documented).

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,116 @@
+# Release Runbook
+
+Use this guide when publishing a new IDX0 desktop release.
+
+## 1. One-Time Prerequisites
+
+1. Confirm Apple credentials for notarization are stored in a keychain profile:
+
+```bash
+xcrun notarytool store-credentials "<profile-name>" --apple-id "<apple-id>" --team-id "<team-id>" --password "<app-specific-password>"
+```
+
+2. Confirm your DMG signing identity exists:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+3. Confirm GitHub CLI auth:
+
+```bash
+gh auth status
+```
+
+## 2. Per-Release Preflight
+
+1. Choose version `X.Y.Z`.
+2. Make sure this repo and `README.md` are clean (no unstaged/staged local edits).
+3. If you want idx-web auto-update, make sure the target file is clean too.
+4. From repo root, verify project checks:
+
+```bash
+./scripts/setup.sh
+xcodegen generate
+xcodebuild -project idx0.xcodeproj -scheme idx0 -destination 'platform=macOS' test
+./scripts/maintainability-gate.sh
+```
+
+## 3. Build + Notarize Artifacts
+
+Run:
+
+```bash
+./scripts/manual-release.sh \
+  --version X.Y.Z \
+  --notary-profile "<profile-name>" \
+  --dmg-sign-identity "Developer ID Application: <name> (<team-id>)"
+```
+
+Default behavior:
+
+- Runs setup/project generation/tests/maintainability gate.
+- Builds release app.
+- Packages `zip`, `tar.gz`, and `dmg`.
+- Signs and notarizes artifacts.
+- Staples DMG.
+- Runs DMG smoke test.
+
+Artifacts are written to `dist/`:
+
+- `IDX0-X.Y.Z.dmg`
+- `IDX0-X.Y.Z-mac.zip`
+- `IDX0-X.Y.Z-mac.tar.gz`
+- `SHA256SUMS.txt`
+
+## 4. Publish GitHub Release + Update Download Links
+
+Draft release (default):
+
+```bash
+./scripts/publish-github-release.sh --version X.Y.Z
+```
+
+Published release:
+
+```bash
+./scripts/publish-github-release.sh --version X.Y.Z --publish
+```
+
+Notes:
+
+- `--version` is required.
+- Download URL now follows the selected `--repo` (or current repo).
+- Default idx-web path is `/Users/gal/Documents/Github/idx-web/index.html`.
+- Override idx-web path with `--idx-web-index <path>`.
+- Enforce idx-web update success with `--require-idx-web-update`.
+- If idx-web update is not required and preflight fails, the script warns and skips idx-web automation.
+
+## 5. Verify Release
+
+1. Validate release assets:
+
+```bash
+gh release view vX.Y.Z --repo galz10/IDX0
+```
+
+2. Open release page and verify download links.
+3. Confirm `README.md` download link points to `vX.Y.Z`.
+4. If idx-web update was enabled, confirm CTA URL and `data-release-version`.
+
+## 6. Recommended Command Template
+
+```bash
+VERSION="X.Y.Z"
+NOTARY_PROFILE="<profile-name>"
+DMG_SIGN_IDENTITY="Developer ID Application: <name> (<team-id>)"
+
+./scripts/manual-release.sh \
+  --version "$VERSION" \
+  --notary-profile "$NOTARY_PROFILE" \
+  --dmg-sign-identity "$DMG_SIGN_IDENTITY"
+
+./scripts/publish-github-release.sh \
+  --version "$VERSION" \
+  --publish
+```

--- a/scripts/manual-release.sh
+++ b/scripts/manual-release.sh
@@ -15,8 +15,9 @@ RUN_SETUP=1
 RUN_PROJECT_GEN=1
 RUN_TESTS=1
 RUN_MAINTAINABILITY=1
-NOTARIZE=0
 NOTARY_PROFILE="${NOTARY_PROFILE:-}"
+DMG_SIGNING_IDENTITY="${DMG_SIGNING_IDENTITY:-}"
+RUN_DMG_SMOKE_TEST=1
 
 OUTPUT_DIR="$ROOT_DIR/dist"
 DERIVED_DATA_PATH="$ROOT_DIR/.build/derived-release"
@@ -36,8 +37,9 @@ Options:
   --skip-project-gen          Skip xcodegen generate
   --skip-tests                Skip xcodebuild test gate
   --skip-maintainability      Skip ./scripts/maintainability-gate.sh
-  --notarize                  Submit zip + dmg to Apple notarization and staple dmg
-  --notary-profile <name>     Keychain profile for notarytool (required with --notarize if NOTARY_PROFILE is unset)
+  --skip-dmg-smoke-test       Skip post-notarization DMG smoke test
+  --notary-profile <name>     Keychain profile for notarytool (required; can also use NOTARY_PROFILE)
+  --dmg-sign-identity <name>  Signing identity for DMG codesign (required; can also use DMG_SIGNING_IDENTITY)
   -h, --help                  Show this help text
 EOF
 }
@@ -80,12 +82,16 @@ while [[ $# -gt 0 ]]; do
       RUN_MAINTAINABILITY=0
       shift
       ;;
-    --notarize)
-      NOTARIZE=1
+    --skip-dmg-smoke-test)
+      RUN_DMG_SMOKE_TEST=0
       shift
       ;;
     --notary-profile)
       NOTARY_PROFILE="${2:-}"
+      shift 2
+      ;;
+    --dmg-sign-identity)
+      DMG_SIGNING_IDENTITY="${2:-}"
       shift 2
       ;;
     -h|--help)
@@ -105,9 +111,15 @@ if [[ -z "$VERSION" ]]; then
   exit 1
 fi
 
-if [[ "$NOTARIZE" -eq 1 && -z "$NOTARY_PROFILE" ]]; then
-  echo "error: notarization requested but no notary profile provided." >&2
+if [[ -z "$NOTARY_PROFILE" ]]; then
+  echo "error: no notary profile provided." >&2
   echo "hint: pass --notary-profile <name> or export NOTARY_PROFILE=<name>" >&2
+  exit 1
+fi
+
+if [[ -z "$DMG_SIGNING_IDENTITY" ]]; then
+  echo "error: no DMG signing identity provided." >&2
+  echo "hint: pass --dmg-sign-identity <name> or export DMG_SIGNING_IDENTITY=<name>" >&2
   exit 1
 fi
 
@@ -119,10 +131,7 @@ require_cmd hdiutil
 require_cmd shasum
 require_cmd codesign
 require_cmd spctl
-
-if [[ "$NOTARIZE" -eq 1 ]]; then
-  require_cmd xcrun
-fi
+require_cmd xcrun
 
 echo "==> Manual release configuration"
 echo "Version: $VERSION"
@@ -132,10 +141,10 @@ echo "Run setup: $RUN_SETUP"
 echo "Run project generation: $RUN_PROJECT_GEN"
 echo "Run tests: $RUN_TESTS"
 echo "Run maintainability gate: $RUN_MAINTAINABILITY"
-echo "Notarize: $NOTARIZE"
-if [[ "$NOTARIZE" -eq 1 ]]; then
-  echo "Notary profile: $NOTARY_PROFILE"
-fi
+echo "Notarize: 1"
+echo "Notary profile: $NOTARY_PROFILE"
+echo "DMG signing identity: $DMG_SIGNING_IDENTITY"
+echo "Run DMG smoke test: $RUN_DMG_SMOKE_TEST"
 echo
 
 mkdir -p "$OUTPUT_DIR"
@@ -202,7 +211,19 @@ tar -czf "$TAR_PATH" -C "$(dirname "$APP_PATH")" "$(basename "$APP_PATH")"
 
 echo "==> Packaging dmg"
 DMG_STAGE_DIR="$(mktemp -d "$ROOT_DIR/.build/dmg-stage.XXXXXX")"
+DMG_MOUNT_POINT=""
+DMG_DEVICE=""
 cleanup() {
+  if [[ -n "${DMG_DEVICE:-}" ]]; then
+    hdiutil detach "$DMG_DEVICE" >/dev/null 2>&1 || true
+    DMG_DEVICE=""
+  elif [[ -n "${DMG_MOUNT_POINT:-}" ]]; then
+    hdiutil detach "$DMG_MOUNT_POINT" >/dev/null 2>&1 || true
+    DMG_MOUNT_POINT=""
+  fi
+  if [[ -n "${DMG_MOUNT_POINT:-}" ]]; then
+    rm -rf "$DMG_MOUNT_POINT"
+  fi
   rm -rf "$DMG_STAGE_DIR"
 }
 trap cleanup EXIT
@@ -212,15 +233,47 @@ ln -s /Applications "$DMG_STAGE_DIR/Applications"
 rm -f "$DMG_PATH"
 hdiutil create -volname "IDX0" -srcfolder "$DMG_STAGE_DIR" -ov -format UDZO "$DMG_PATH"
 
-if [[ "$NOTARIZE" -eq 1 ]]; then
-  echo "==> Notarizing zip"
-  xcrun notarytool submit "$ZIP_PATH" --keychain-profile "$NOTARY_PROFILE" --wait
+echo "==> Signing dmg"
+codesign --force --sign "$DMG_SIGNING_IDENTITY" --timestamp "$DMG_PATH"
+codesign --verify --verbose=2 "$DMG_PATH"
 
-  echo "==> Notarizing dmg"
-  xcrun notarytool submit "$DMG_PATH" --keychain-profile "$NOTARY_PROFILE" --wait
+echo "==> Notarizing zip"
+xcrun notarytool submit "$ZIP_PATH" --keychain-profile "$NOTARY_PROFILE" --wait
 
-  echo "==> Stapling dmg"
-  xcrun stapler staple "$DMG_PATH"
+echo "==> Notarizing dmg"
+xcrun notarytool submit "$DMG_PATH" --keychain-profile "$NOTARY_PROFILE" --wait
+
+echo "==> Stapling dmg"
+xcrun stapler staple "$DMG_PATH"
+
+if [[ "$RUN_DMG_SMOKE_TEST" -eq 1 ]]; then
+  echo "==> Running dmg smoke test"
+  DMG_MOUNT_POINT="$(mktemp -d "$ROOT_DIR/.build/dmg-mount.XXXXXX")"
+  ATTACH_OUTPUT="$(hdiutil attach "$DMG_PATH" -nobrowse -readonly -mountpoint "$DMG_MOUNT_POINT")"
+  DMG_DEVICE="$(echo "$ATTACH_OUTPUT" | awk '/^\/dev\// {print $1; exit}')"
+
+  MOUNTED_APP_PATH="$DMG_MOUNT_POINT/idx0.app"
+  if [[ ! -d "$MOUNTED_APP_PATH" ]]; then
+    echo "error: smoke test failed; mounted DMG missing idx0.app at $MOUNTED_APP_PATH" >&2
+    exit 1
+  fi
+
+  if [[ ! -L "$DMG_MOUNT_POINT/Applications" ]]; then
+    echo "error: smoke test failed; mounted DMG missing /Applications symlink" >&2
+    exit 1
+  fi
+
+  codesign --verify --deep --strict --verbose=2 "$MOUNTED_APP_PATH"
+  spctl --assess --type execute --verbose "$MOUNTED_APP_PATH"
+
+  if [[ -n "$DMG_DEVICE" ]]; then
+    hdiutil detach "$DMG_DEVICE" >/dev/null
+    DMG_DEVICE=""
+  else
+    hdiutil detach "$DMG_MOUNT_POINT" >/dev/null
+  fi
+  rm -rf "$DMG_MOUNT_POINT"
+  DMG_MOUNT_POINT=""
 fi
 
 echo "==> Writing SHA256 checksums"

--- a/scripts/manual-release.sh
+++ b/scripts/manual-release.sh
@@ -214,16 +214,17 @@ DMG_STAGE_DIR="$(mktemp -d "$ROOT_DIR/.build/dmg-stage.XXXXXX")"
 DMG_MOUNT_POINT=""
 DMG_DEVICE=""
 cleanup() {
+  local mount_point="${DMG_MOUNT_POINT:-}"
   if [[ -n "${DMG_DEVICE:-}" ]]; then
     hdiutil detach "$DMG_DEVICE" >/dev/null 2>&1 || true
     DMG_DEVICE=""
-  elif [[ -n "${DMG_MOUNT_POINT:-}" ]]; then
-    hdiutil detach "$DMG_MOUNT_POINT" >/dev/null 2>&1 || true
-    DMG_MOUNT_POINT=""
+  elif [[ -n "$mount_point" ]]; then
+    hdiutil detach "$mount_point" >/dev/null 2>&1 || true
   fi
-  if [[ -n "${DMG_MOUNT_POINT:-}" ]]; then
-    rm -rf "$DMG_MOUNT_POINT"
+  if [[ -n "$mount_point" ]]; then
+    rm -rf "$mount_point"
   fi
+  DMG_MOUNT_POINT=""
   rm -rf "$DMG_STAGE_DIR"
 }
 trap cleanup EXIT

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -10,7 +10,8 @@ if [[ -z "${DEFAULT_VERSION:-}" ]]; then
   DEFAULT_VERSION="0.0.1"
 fi
 
-VERSION="$DEFAULT_VERSION"
+VERSION=""
+VERSION_WAS_SET=0
 DIST_DIR="$ROOT_DIR/dist"
 REPO=""
 TITLE=""
@@ -21,6 +22,13 @@ MAKE_DRAFT=1
 PRERELEASE=0
 OPEN_WEB=0
 PUSH_TAG=1
+IDX_WEB_INDEX_PATH="/Users/gal/Documents/Github/idx-web/index.html"
+README_PATH="$ROOT_DIR/README.md"
+
+COMMITTED_REPOS=()
+PUSHED_REPOS=()
+SKIPPED_REPOS=()
+WARNED_REPOS=()
 
 usage() {
   cat <<'EOF'
@@ -30,7 +38,7 @@ Usage:
   ./scripts/publish-github-release.sh [options]
 
 Options:
-  --version <semver>          Release version. Defaults to MARKETING_VERSION from project.yml.
+  --version <semver>          Release version (required).
   --dist-dir <dir>            Artifact directory. Default: ./dist
   --repo <owner/name>         GitHub repo (falls back to current gh repo context)
   --title <text>              Release title. Default: "IDX0 v<version>"
@@ -83,6 +91,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --version)
       VERSION="${2:-}"
+      VERSION_WAS_SET=1
       shift 2
       ;;
     --dist-dir)
@@ -137,6 +146,11 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ "$VERSION_WAS_SET" -ne 1 ]]; then
+  echo "error: --version is required." >&2
+  exit 1
+fi
+
 VERSION="$(normalize_version "$VERSION")"
 if [[ -z "$VERSION" ]]; then
   echo "error: version is empty" >&2
@@ -156,6 +170,129 @@ fi
 
 require_cmd git
 require_cmd gh
+require_cmd perl
+
+release_download_url() {
+  local version="$1"
+  echo "https://github.com/galz10/IDX0/releases/download/v${version}/IDX0-${version}.dmg"
+}
+
+patch_idx_web_download_link() {
+  local file="$1"
+  local version="$2"
+  local download_url="$3"
+
+  if [[ ! -f "$file" ]]; then
+    echo "error: idx-web download target not found: $file" >&2
+    exit 1
+  fi
+
+  perl -0pi -e "s~https://github\\.com/galz10/IDX0/releases/download/v[^\"']+/IDX0-[^\"']*\\.dmg~${download_url}~g" "$file"
+  perl -0pi -e "s~(data-release-version=\")[^\"]*(\")~\${1}${version}\${2}~g" "$file"
+}
+
+patch_readme_download_link() {
+  local file="$1"
+  local download_url="$2"
+
+  if [[ ! -f "$file" ]]; then
+    echo "error: README not found at $file" >&2
+    exit 1
+  fi
+
+  perl -0pi -e "s~https://github\\.com/galz10/IDX0/releases/(?:tag/v[0-9A-Za-z._-]+|download/v[0-9A-Za-z._-]+/IDX0-[0-9A-Za-z._-]+(?:-arm)?\\.dmg)~${download_url}~g" "$file"
+}
+
+hash_file() {
+  local file="$1"
+  shasum -a 256 "$file" | awk '{print $1}'
+}
+
+record_skip() {
+  local message="$1"
+  SKIPPED_REPOS+=("$message")
+}
+
+record_warning() {
+  local message="$1"
+  WARNED_REPOS+=("$message")
+}
+
+auto_commit_and_push_file() {
+  local repo_hint="$1"
+  local target_file="$2"
+  local repo_label="$3"
+  local optional_repo="${4:-0}"
+  local commit_message="$5"
+
+  if [[ ! -d "$repo_hint" ]]; then
+    if [[ "$optional_repo" -eq 1 ]]; then
+      record_warning "$repo_label: repo path not found ($repo_hint)"
+      return 0
+    fi
+    echo "error: repo path not found: $repo_hint" >&2
+    exit 1
+  fi
+
+  if ! git -C "$repo_hint" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [[ "$optional_repo" -eq 1 ]]; then
+      record_warning "$repo_label: not a git repo, skipped git automation"
+      return 0
+    fi
+    echo "error: not a git repo: $repo_hint" >&2
+    exit 1
+  fi
+
+  local repo_root
+  repo_root="$(git -C "$repo_hint" rev-parse --show-toplevel)"
+
+  if [[ ! -f "$target_file" ]]; then
+    record_skip "$repo_label: target file missing ($target_file)"
+    return 0
+  fi
+
+  local rel_path="${target_file#$repo_root/}"
+  if [[ "$rel_path" == "$target_file" ]]; then
+    echo "error: file is outside git repo ($repo_label): $target_file" >&2
+    exit 1
+  fi
+
+  if [[ -z "$(git -C "$repo_root" status --porcelain -- "$rel_path")" ]]; then
+    record_skip "$repo_label: no changes in $rel_path"
+    return 0
+  fi
+
+  git -C "$repo_root" add -- "$rel_path"
+  if git -C "$repo_root" diff --cached --quiet -- "$rel_path"; then
+    record_skip "$repo_label: no staged changes in $rel_path"
+    return 0
+  fi
+
+  git -C "$repo_root" commit -m "$commit_message" -- "$rel_path"
+  COMMITTED_REPOS+=("$repo_label")
+
+  local current_branch
+  current_branch="$(git -C "$repo_root" branch --show-current)"
+  if [[ -z "$current_branch" ]]; then
+    record_warning "$repo_label: detached HEAD, skipped push"
+    return 0
+  fi
+
+  if git -C "$repo_root" rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" >/dev/null 2>&1; then
+    if git -C "$repo_root" push; then
+      PUSHED_REPOS+=("$repo_label")
+    else
+      record_warning "$repo_label: push failed, commit left locally"
+    fi
+    return 0
+  fi
+
+  if git -C "$repo_root" push -u origin "$current_branch"; then
+    PUSHED_REPOS+=("$repo_label")
+  else
+    record_warning "$repo_label: push -u origin $current_branch failed, commit left locally"
+  fi
+}
 
 if ! gh auth status >/dev/null 2>&1; then
   echo "error: GitHub CLI is not authenticated." >&2
@@ -236,12 +373,74 @@ else
   gh release create "${CREATE_ARGS[@]}"
 fi
 
+DOWNLOAD_URL="$(release_download_url "$VERSION")"
+
+README_BEFORE_HASH="$(hash_file "$README_PATH")"
+patch_readme_download_link "$README_PATH" "$DOWNLOAD_URL"
+README_AFTER_HASH="$(hash_file "$README_PATH")"
+README_CHANGED=0
+if [[ "$README_BEFORE_HASH" != "$README_AFTER_HASH" ]]; then
+  README_CHANGED=1
+fi
+
+IDX_WEB_CHANGED=0
+if [[ -f "$IDX_WEB_INDEX_PATH" ]]; then
+  IDX_WEB_BEFORE_HASH="$(hash_file "$IDX_WEB_INDEX_PATH")"
+  patch_idx_web_download_link "$IDX_WEB_INDEX_PATH" "$VERSION" "$DOWNLOAD_URL"
+  IDX_WEB_AFTER_HASH="$(hash_file "$IDX_WEB_INDEX_PATH")"
+  if [[ "$IDX_WEB_BEFORE_HASH" != "$IDX_WEB_AFTER_HASH" ]]; then
+    IDX_WEB_CHANGED=1
+  fi
+else
+  echo "error: idx-web target file not found: $IDX_WEB_INDEX_PATH" >&2
+  exit 1
+fi
+
+if [[ "$README_CHANGED" -eq 1 ]]; then
+  auto_commit_and_push_file "$ROOT_DIR" "$README_PATH" "IDX0" 0 "chore(release): update README download link for $TAG"
+else
+  record_skip "IDX0: README already points at $DOWNLOAD_URL"
+fi
+
+if [[ "$IDX_WEB_CHANGED" -eq 1 ]]; then
+  auto_commit_and_push_file "$(dirname "$IDX_WEB_INDEX_PATH")" "$IDX_WEB_INDEX_PATH" "idx-web" 1 "chore(release): update download CTA for $TAG"
+else
+  record_skip "idx-web: Download CTA already points at $DOWNLOAD_URL"
+fi
+
 echo
 echo "==> Release ready"
 echo "Repo: $REPO"
 echo "Tag: $TAG"
+echo "Download URL: $DOWNLOAD_URL"
 echo "Assets:"
 printf ' - %s\n' "$DMG_PATH" "$ZIP_PATH" "$TAR_PATH" "$CHECKSUM_PATH"
+
+echo
+echo "==> Git automation summary"
+if [[ "${#COMMITTED_REPOS[@]}" -gt 0 ]]; then
+  printf 'Committed:\n'
+  printf ' - %s\n' "${COMMITTED_REPOS[@]}"
+else
+  echo "Committed: none"
+fi
+
+if [[ "${#PUSHED_REPOS[@]}" -gt 0 ]]; then
+  printf 'Pushed:\n'
+  printf ' - %s\n' "${PUSHED_REPOS[@]}"
+else
+  echo "Pushed: none"
+fi
+
+if [[ "${#SKIPPED_REPOS[@]}" -gt 0 ]]; then
+  printf 'Skipped:\n'
+  printf ' - %s\n' "${SKIPPED_REPOS[@]}"
+fi
+
+if [[ "${#WARNED_REPOS[@]}" -gt 0 ]]; then
+  printf 'Warnings:\n'
+  printf ' - %s\n' "${WARNED_REPOS[@]}"
+fi
 
 if [[ "$OPEN_WEB" -eq 1 ]]; then
   gh release view "$TAG" --repo "$REPO" --web

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -22,7 +22,9 @@ MAKE_DRAFT=1
 PRERELEASE=0
 OPEN_WEB=0
 PUSH_TAG=1
-IDX_WEB_INDEX_PATH="/Users/gal/Documents/Github/idx-web/index.html"
+IDX_WEB_INDEX_DEFAULT_PATH="/Users/gal/Documents/Github/idx-web/index.html"
+IDX_WEB_INDEX_PATH="${IDX_WEB_INDEX_PATH:-$IDX_WEB_INDEX_DEFAULT_PATH}"
+REQUIRE_IDX_WEB_UPDATE=0
 README_PATH="$ROOT_DIR/README.md"
 
 COMMITTED_REPOS=()
@@ -48,6 +50,8 @@ Options:
   --publish                   Create release as published (not draft)
   --prerelease                Mark release as prerelease
   --no-push-tag               Do not push tag to origin
+  --idx-web-index <path>      Override idx-web download target (default: /Users/gal/Documents/Github/idx-web/index.html)
+  --require-idx-web-update    Fail if idx-web update cannot run
   --open                      Open the release page in browser after create/update
   -h, --help                  Show this help text
 
@@ -130,6 +134,14 @@ while [[ $# -gt 0 ]]; do
       PUSH_TAG=0
       shift
       ;;
+    --idx-web-index)
+      IDX_WEB_INDEX_PATH="${2:-}"
+      shift 2
+      ;;
+    --require-idx-web-update)
+      REQUIRE_IDX_WEB_UPDATE=1
+      shift
+      ;;
     --open)
       OPEN_WEB=1
       shift
@@ -173,8 +185,10 @@ require_cmd gh
 require_cmd perl
 
 release_download_url() {
-  local version="$1"
-  echo "https://github.com/galz10/IDX0/releases/download/v${version}/IDX0-${version}.dmg"
+  local repo="$1"
+  local tag="$2"
+  local dmg_name="$3"
+  echo "https://github.com/${repo}/releases/download/${tag}/${dmg_name}"
 }
 
 patch_idx_web_download_link() {
@@ -187,7 +201,7 @@ patch_idx_web_download_link() {
     exit 1
   fi
 
-  perl -0pi -e "s~https://github\\.com/galz10/IDX0/releases/download/v[^\"']+/IDX0-[^\"']*\\.dmg~${download_url}~g" "$file"
+  perl -0pi -e "s~https://github\\.com/[^/]+/[^/]+/releases/download/v[^\"']+/IDX0-[^\"']*\\.dmg~${download_url}~g" "$file"
   perl -0pi -e "s~(data-release-version=\")[^\"]*(\")~\${1}${version}\${2}~g" "$file"
 }
 
@@ -200,7 +214,7 @@ patch_readme_download_link() {
     exit 1
   fi
 
-  perl -0pi -e "s~https://github\\.com/galz10/IDX0/releases/(?:tag/v[0-9A-Za-z._-]+|download/v[0-9A-Za-z._-]+/IDX0-[0-9A-Za-z._-]+(?:-arm)?\\.dmg)~${download_url}~g" "$file"
+  perl -0pi -e "s~https://github\\.com/[^/]+/[^/]+/releases/(?:tag/v[0-9A-Za-z._-]+|download/v[0-9A-Za-z._-]+/IDX0-[0-9A-Za-z._-]+(?:-arm)?\\.dmg)~${download_url}~g" "$file"
 }
 
 hash_file() {
@@ -216,6 +230,73 @@ record_skip() {
 record_warning() {
   local message="$1"
   WARNED_REPOS+=("$message")
+}
+
+preflight_patch_target() {
+  local repo_hint="$1"
+  local target_file="$2"
+  local repo_label="$3"
+  local required="${4:-1}"
+
+  if [[ -z "$target_file" ]]; then
+    if [[ "$required" -eq 1 ]]; then
+      echo "error: $repo_label target path is empty." >&2
+      exit 1
+    fi
+    record_warning "$repo_label: target path is empty, skipped"
+    return 1
+  fi
+
+  if [[ ! -f "$target_file" ]]; then
+    if [[ "$required" -eq 1 ]]; then
+      echo "error: $repo_label target file not found: $target_file" >&2
+      exit 1
+    fi
+    record_warning "$repo_label: target file not found ($target_file), skipped"
+    return 1
+  fi
+
+  if [[ ! -d "$repo_hint" ]]; then
+    if [[ "$required" -eq 1 ]]; then
+      echo "error: repo path not found: $repo_hint" >&2
+      exit 1
+    fi
+    record_warning "$repo_label: repo path not found ($repo_hint), skipped"
+    return 1
+  fi
+
+  if ! git -C "$repo_hint" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [[ "$required" -eq 1 ]]; then
+      echo "error: not a git repo: $repo_hint" >&2
+      exit 1
+    fi
+    record_warning "$repo_label: not a git repo ($repo_hint), skipped"
+    return 1
+  fi
+
+  local repo_root
+  repo_root="$(git -C "$repo_hint" rev-parse --show-toplevel)"
+  local rel_path="${target_file#$repo_root/}"
+  if [[ "$rel_path" == "$target_file" ]]; then
+    if [[ "$required" -eq 1 ]]; then
+      echo "error: file is outside git repo ($repo_label): $target_file" >&2
+      exit 1
+    fi
+    record_warning "$repo_label: file is outside git repo ($target_file), skipped"
+    return 1
+  fi
+
+  if [[ -n "$(git -C "$repo_root" status --porcelain -- "$rel_path")" ]]; then
+    if [[ "$required" -eq 1 ]]; then
+      echo "error: pre-existing local changes detected in $repo_label ($rel_path)." >&2
+      echo "hint: commit or stash file changes before running release automation." >&2
+      exit 1
+    fi
+    record_warning "$repo_label: pre-existing local changes in $rel_path, skipped"
+    return 1
+  fi
+
+  return 0
 }
 
 auto_commit_and_push_file() {
@@ -321,6 +402,15 @@ if [[ -n "$NOTES_FILE" && ! -f "$NOTES_FILE" ]]; then
   exit 1
 fi
 
+DOWNLOAD_URL="$(release_download_url "$REPO" "$TAG" "$(basename "$DMG_PATH")")"
+
+preflight_patch_target "$ROOT_DIR" "$README_PATH" "IDX0" 1
+
+IDX_WEB_CAN_UPDATE=1
+if ! preflight_patch_target "$(dirname "$IDX_WEB_INDEX_PATH")" "$IDX_WEB_INDEX_PATH" "idx-web" "$REQUIRE_IDX_WEB_UPDATE"; then
+  IDX_WEB_CAN_UPDATE=0
+fi
+
 if [[ "$PUSH_TAG" -eq 1 ]]; then
   if ! git rev-parse "$TAG" >/dev/null 2>&1; then
     if [[ -n "$TARGET_REF" ]]; then
@@ -373,8 +463,6 @@ else
   gh release create "${CREATE_ARGS[@]}"
 fi
 
-DOWNLOAD_URL="$(release_download_url "$VERSION")"
-
 README_BEFORE_HASH="$(hash_file "$README_PATH")"
 patch_readme_download_link "$README_PATH" "$DOWNLOAD_URL"
 README_AFTER_HASH="$(hash_file "$README_PATH")"
@@ -384,16 +472,13 @@ if [[ "$README_BEFORE_HASH" != "$README_AFTER_HASH" ]]; then
 fi
 
 IDX_WEB_CHANGED=0
-if [[ -f "$IDX_WEB_INDEX_PATH" ]]; then
+if [[ "$IDX_WEB_CAN_UPDATE" -eq 1 ]]; then
   IDX_WEB_BEFORE_HASH="$(hash_file "$IDX_WEB_INDEX_PATH")"
   patch_idx_web_download_link "$IDX_WEB_INDEX_PATH" "$VERSION" "$DOWNLOAD_URL"
   IDX_WEB_AFTER_HASH="$(hash_file "$IDX_WEB_INDEX_PATH")"
   if [[ "$IDX_WEB_BEFORE_HASH" != "$IDX_WEB_AFTER_HASH" ]]; then
     IDX_WEB_CHANGED=1
   fi
-else
-  echo "error: idx-web target file not found: $IDX_WEB_INDEX_PATH" >&2
-  exit 1
 fi
 
 if [[ "$README_CHANGED" -eq 1 ]]; then
@@ -402,9 +487,9 @@ else
   record_skip "IDX0: README already points at $DOWNLOAD_URL"
 fi
 
-if [[ "$IDX_WEB_CHANGED" -eq 1 ]]; then
+if [[ "$IDX_WEB_CAN_UPDATE" -eq 1 && "$IDX_WEB_CHANGED" -eq 1 ]]; then
   auto_commit_and_push_file "$(dirname "$IDX_WEB_INDEX_PATH")" "$IDX_WEB_INDEX_PATH" "idx-web" 1 "chore(release): update download CTA for $TAG"
-else
+elif [[ "$IDX_WEB_CAN_UPDATE" -eq 1 ]]; then
   record_skip "idx-web: Download CTA already points at $DOWNLOAD_URL"
 fi
 


### PR DESCRIPTION
## Summary

Harden release scripts for a two-step manual release flow by enforcing notarization prerequisites in packaging and automating post-release download-link updates.

## Details

- `scripts/manual-release.sh`
  - Enforces notary profile input and DMG signing identity before any build work starts.
  - Makes notarization part of the default release path and signs the DMG before notarization.
  - Adds a default-on DMG smoke-test gate that mounts the image, validates required artifacts, verifies code signing, runs Gatekeeper assessment, and cleanly unmounts.
- `scripts/publish-github-release.sh`
  - Requires explicit `--version` input.
  - Keeps draft-first release behavior.
  - Updates both download targets after upload:
    - `README.md` install link
    - `/Users/gal/Documents/Github/idx-web/index.html` download CTA URL + `data-release-version`
  - Adds per-repo git automation for changed files with commit/push attempts and clear committed/pushed/skipped/warning summaries.

## Related Issues

N/A

## How to Validate

1. Verify fail-fast release prerequisites:
   - `./scripts/manual-release.sh`
   - Expected: exits with `error: no notary profile provided.`
2. Verify second fail-fast gate:
   - `NOTARY_PROFILE=test ./scripts/manual-release.sh`
   - Expected: exits with `error: no DMG signing identity provided.`
3. Verify publish script requires explicit version:
   - `./scripts/publish-github-release.sh`
   - Expected: exits with `error: --version is required.`
4. Run test suite:
   - `xcodebuild -project idx0.xcodeproj -scheme idx0 -destination 'platform=macOS' test`
   - Current result in this environment: fails on pre-existing `SessionServiceTests` assertions (`testNiriColumnResizePersistsPreferredWidths`, `testNiriDefaultTileSizesApplyOnlyToNewTiles`, `testNiriItemResizePersistsPreferredHeights`).

## Pre-Merge Checklist

- [x] Builds successfully (`xcodebuild` / Xcode)
- [ ] Added/updated tests (if needed)
- [ ] Updated relevant documentation and README (if needed)
- [ ] Noted breaking changes (if any)
- [x] Tested on macOS
