### PR TITLE
feat(browser): add first-use browser control opt-in and setup

### DIFF
--- a/idx0.xcodeproj/project.pbxproj
+++ b/idx0.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		14D7D7D82D5BB685BDCE5851 /* excalidraw-build-manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = DFEC4330AF1DE7C978BA59E8 /* excalidraw-build-manifest.json */; };
 		171E27C515BB614D1D8283B6 /* InlineSafetySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE452CDCBD97B412A836AE6 /* InlineSafetySettings.swift */; };
 		18FBDF897EAC7B0F4E8503FD /* SessionContainerView+NiriDragResize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A3B6B056A35C674DB49A2E /* SessionContainerView+NiriDragResize.swift */; };
+		1968EC9A62A06303633848F5 /* BrowserControlConsentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467BBA449474404E3CA394B9 /* BrowserControlConsentSheet.swift */; };
 		1A4F10D868A0E1ADE5022C32 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = E040B0FC30190D925785844A /* Session.swift */; };
 		1A532D3B915A03ADAE33F692 /* GhosttyTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF32A5CDE91085A45FAEF298 /* GhosttyTerminalView.swift */; };
 		1C72135109AB0ADCE4FF8352 /* IPCCommandRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AC2552BD0D866484FFA51B /* IPCCommandRouter.swift */; };
@@ -42,7 +43,6 @@
 		260C5CC03FCDD41F93EA7867 /* InlineSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5460029DE37A1C42C476E9 /* InlineSettingsView.swift */; };
 		26FA772FB59719EE96B56CD4 /* SessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E869F53140CDC4C857F1C4 /* SessionModels.swift */; };
 		275AE7A80AD803D3E65870CC /* GhosttyAppHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8575A62595B953CB87681D3E /* GhosttyAppHost.swift */; };
-		2AE9DE55597E704B7B99B0EF /* NiriTileSpotlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA0B16E5CCCBFB1FAA5620C /* NiriTileSpotlight.swift */; };
 		2C239931857F2B7586F7AD86 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9962C2537A206B836AAA1CE /* AppSettings.swift */; };
 		2E56891B5B216C3D8A39510F /* AppearanceSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9C7E86A82614D71AC3D0D9 /* AppearanceSettingsTab.swift */; };
 		2EE1C95E4D9823EA95497533 /* idx0.icns.backup-20260322-075809 in Resources */ = {isa = PBXBuildFile; fileRef = 150785B3AEE2598ED5427E3D /* idx0.icns.backup-20260322-075809 */; };
@@ -61,6 +61,7 @@
 		3EF6ECE428D7E215E9DD613B /* VibeCLIDiscoveryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC139CC9450EA9A8A81A2AD /* VibeCLIDiscoveryService.swift */; };
 		3F370869C5D7E4FFB73FE800 /* SessionContainerView+NiriItemViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D07E1D74241531F78C9443 /* SessionContainerView+NiriItemViews.swift */; };
 		41092C03A899796A0711FC42 /* SessionServiceTests+Niri.swift in Sources */ = {isa = PBXBuildFile; fileRef = C154F30A5F338A27AB53712F /* SessionServiceTests+Niri.swift */; };
+		4116D46FD4291623E6BDDDBD /* SessionServiceTests+BrowserControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1411C64FF77E9D34CFA71265 /* SessionServiceTests+BrowserControl.swift */; };
 		458A0057B76598B3D58CD0F3 /* SessionModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 779E0989D99E1DDC0D97FD22 /* SessionModelTests.swift */; };
 		45F746595D800D55543F669A /* TerminalThemeCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F233D8A50FB6FF95CF6C2EE7 /* TerminalThemeCatalog.swift */; };
 		48CD82F3363A82E058277D62 /* PaneTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA8C7331AA94A8E5C8F6DCF /* PaneTreeView.swift */; };
@@ -74,6 +75,7 @@
 		553B8C11C5536D6292D03BD5 /* SessionServiceTests+Launch.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BC04FF0FF385A5961DB941 /* SessionServiceTests+Launch.swift */; };
 		55ECD5BC9024D9F952EC63FD /* MultiPaneTerminalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD45C1A409BBBB63FF2426F /* MultiPaneTerminalView.swift */; };
 		56234CCB329323A350942A0E /* SessionService+SessionOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3D11360E25BF9244274C97B /* SessionService+SessionOps.swift */; };
+		5884A8FBF5C47453B469980A /* TerminalMonitorServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0DF5DDE163F1A0D142C48A1 /* TerminalMonitorServiceTests.swift */; };
 		58987615D32B830F852135E5 /* T3CodeRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F79E05AB6D634F53DE988F5 /* T3CodeRuntimeTests.swift */; };
 		5EF9A714D8C684B843006A0E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D1D4C1C59381DEB755085208 /* Assets.xcassets */; };
 		5F13BE8A667BCCFB0BA879E6 /* AgentOutputScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DC53446A59CB69B5DBD424E /* AgentOutputScanner.swift */; };
@@ -90,6 +92,8 @@
 		69D61B8290DCFD28F70CBDAA /* WorkflowModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8966AEA81C75928E237AA817 /* WorkflowModels.swift */; };
 		6CE7AAF4682FDAFAFECE3B7D /* WorkflowStores.swift in Sources */ = {isa = PBXBuildFile; fileRef = E348CC63163C1B52E07B8506 /* WorkflowStores.swift */; };
 		6D5F242BF42126B4C201A625 /* VSCodeRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7FCA5B2CB17DD2E1C5B0EE /* VSCodeRuntimeTests.swift */; };
+		732B5CE5894B8AAB395D5A70 /* BrowserControlSetupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEC20DBE17FA2DE2F5E7E140 /* BrowserControlSetupServiceTests.swift */; };
+		7AAB313E7318042DD6A0131D /* SessionService+LaunchPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AC133221097B436EBAB1F1 /* SessionService+LaunchPolicy.swift */; };
 		7B5F59ED5D78EE2A951F8FBC /* AttentionCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084CE6508D3146437C560DE3 /* AttentionCenter.swift */; };
 		7BE5F38B67778F1D254B885D /* WorkflowRailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27AA169BC08CF6EE14A8627 /* WorkflowRailView.swift */; };
 		7C716586AFB06407163868B7 /* IPCServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE3CDAF378E55CAE439A878 /* IPCServer.swift */; };
@@ -118,9 +122,7 @@
 		9F6995C2F654B9422548C148 /* GitServiceParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90EE0DE10784650DC7094D02 /* GitServiceParsingTests.swift */; };
 		A0AB01333BC4220F20076085 /* ShellIntegrationHealthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AAF63EE32EAE7ED03E3F9F3 /* ShellIntegrationHealthService.swift */; };
 		A122A994F2782295A25D68DD /* SessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6EBE25C09A2F6F2E8B66E9 /* SessionStore.swift */; };
-		A1F4A1B2C3D4E5F60718293A /* SessionService+LaunchPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5C /* SessionService+LaunchPolicy.swift */; };
 		A23649679F38533F0195A526 /* FuzzyMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A57DFA12FE234759A547796 /* FuzzyMatch.swift */; };
-		A2B3C4D5E6F708192A3B4C5D /* OpenCodeRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F60718293A4B5C6D7E /* OpenCodeRuntime.swift */; };
 		A375DD04002E0A4558CAE50F /* WorktreeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3906E4FD5F3EF5BB6539B6C7 /* WorktreeService.swift */; };
 		A50FCD80554EC338D5BA1C99 /* idx0.icns in Resources */ = {isa = PBXBuildFile; fileRef = B5048750915F84088FED8574 /* idx0.icns */; };
 		A5E353B0DD8E950DD86D88F8 /* WorktreeInspectorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA436F0CE3DD4AD2B662DC6 /* WorktreeInspectorSheet.swift */; };
@@ -132,13 +134,14 @@
 		ABCB05668DABC31AA71CF977 /* HandoffComposerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24B9DA71E880339383D7D43 /* HandoffComposerSheet.swift */; };
 		AC0E96F84AA1A2B46939E49A /* SessionContainerView+BrowserSplitResize.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD37B4C15A60B8C9E450BD51 /* SessionContainerView+BrowserSplitResize.swift */; };
 		ADCF4292D8351F942D4DEFF3 /* SessionBrowserController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A24BF75FB7EE9A24CCF2980 /* SessionBrowserController.swift */; };
+		AEB9F9C48C035287145DA1A0 /* BrowserControlSetupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6032736DA955A6FD27D5E81E /* BrowserControlSetupService.swift */; };
 		AFE3451E6F9A754B645F9435 /* SupervisionQueueServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F8B6A69E321355348D4610 /* SupervisionQueueServiceTests.swift */; };
-		B2C3D4E5F60718293A4B5C6D /* OpenCodeRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F60718293A4B5C6D7E8F /* OpenCodeRuntimeTests.swift */; };
-		B2F4A1B2C3D4E5F60718293A /* TerminalMonitorServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B2C3D4E5F60718293A4B5C /* TerminalMonitorServiceTests.swift */; };
 		B38C2362FF1FA6D006B66388 /* MainWindowAlerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6A64222CEF84C19CD92011 /* MainWindowAlerts.swift */; };
 		B5CAACE9CD2D4D5BDFA5BA6B /* GitMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F54BC57F8B1D33CACD3BDB /* GitMonitor.swift */; };
+		B5CFE5F6459F81A8666CB315 /* RestoreLaunchQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1177D409C8A650B1E7C2195E /* RestoreLaunchQueueTests.swift */; };
 		B7B219357B0FDD7940FAE7F1 /* URLRoutingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18F76B8A80EF8F1C875F70AF /* URLRoutingService.swift */; };
 		B90D94F0BE0BFE26A93BAEF3 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE658FF7D978BF701A583AD /* Logger.swift */; };
+		B979DB37F81B4C1D82176614 /* OpenCodeRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9D7D0881CD90FDAA7D118A0 /* OpenCodeRuntimeTests.swift */; };
 		BB80B7E9B71CD45EA416FE14 /* QuickSwitchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D145799AD07A6882DC6625 /* QuickSwitchOverlay.swift */; };
 		BC153A7DE0D6E4176DA9A38A /* NiriOnboardingGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2DF94962EFABB2E7A81F69E /* NiriOnboardingGate.swift */; };
 		BC19750CA3CDDAD79E3C74DC /* InlineSessionSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10430D5FE541E8A7589355A3 /* InlineSessionSettings.swift */; };
@@ -149,10 +152,10 @@
 		C0A4A5965304E63A0BF4553F /* SessionAttentionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B8A6EB207A51CF2A5DCB136 /* SessionAttentionState.swift */; };
 		C13B2218F2761EAD637D9F91 /* SessionDetailsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F726013BE89EA789F943F47A /* SessionDetailsSheet.swift */; };
 		C3EFE3C0F35228889DA5DBF5 /* AppCommandRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164D3E27DB793DF6250CB60F /* AppCommandRegistryTests.swift */; };
-		C3F4A1B2C3D4E5F60718293A /* RestoreLaunchQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1B2C3D4E5F60718293A4B5C /* RestoreLaunchQueueTests.swift */; };
 		C4BF4ED638BB64C3380B9C1F /* T3CodeRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C448F93D9024D3A2D87EFB /* T3CodeRuntime.swift */; };
 		C4DD853D2845C83830C3BCB6 /* SessionServiceIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5186DB32861A1F5757732E2D /* SessionServiceIntegrationTests.swift */; };
 		C9B33E60BEBEAFE88CF419E9 /* WorktreePathGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25D22DAD38D8E3EFB649D270 /* WorktreePathGenerationTests.swift */; };
+		CA1FC091D045423FB05535BF /* OpenCodeRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B93A1507BB453BBDD70153 /* OpenCodeRuntime.swift */; };
 		CA2FF80394C68F4A1BB2F4B8 /* BrowserModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE47596354CF7323C58CE3A9 /* BrowserModels.swift */; };
 		D0A0A761157727FDFB96C9C1 /* NiriAppRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8EAB1EE8E31AFAE297503B /* NiriAppRegistryTests.swift */; };
 		D12D4558CDCE82CA5E170731 /* InlineGeneralSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5385ADD3DADF082CD3893E /* InlineGeneralSettings.swift */; };
@@ -176,6 +179,7 @@
 		E8ADEE219025F24923A990A7 /* LayoutStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D63C7BC71EBD7E31BF944A3 /* LayoutStateTests.swift */; };
 		E9E3AA2DAF596FC94179B679 /* SessionContainerNiriWorkspaceLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D41A657FCE96AB8403908B5 /* SessionContainerNiriWorkspaceLayout.swift */; };
 		EC929DF32DAD540380D36B11 /* AppCommandRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C148B9BDC30B6C6959E7D7 /* AppCommandRegistry.swift */; };
+		EEB3852F18CB4DA5E93C2A3F /* NiriTileSpotlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311CD22F7731839DA5785C05 /* NiriTileSpotlight.swift */; };
 		F4C53DF6B11BED3E1D89E8C6 /* IPCContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 126519A706915EF6A552C36D /* IPCContract.swift */; };
 		F7EC6D8E4650E5265FBE2611 /* FileSystemPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6ED7E9421B0B45E803E9F9D /* FileSystemPaths.swift */; };
 		F85827AECC0D99E9AD51A676 /* CodableSessionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC66C9B0E0BEF3C9699990C /* CodableSessionRecord.swift */; };
@@ -214,10 +218,12 @@
 		0F777BA529A3C61CA2F671D0 /* TerminalMonitorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalMonitorService.swift; sourceTree = "<group>"; };
 		10430D5FE541E8A7589355A3 /* InlineSessionSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineSessionSettings.swift; sourceTree = "<group>"; };
 		10A52A17C7439012AC5990DE /* TerminalTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTheme.swift; sourceTree = "<group>"; };
+		1177D409C8A650B1E7C2195E /* RestoreLaunchQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreLaunchQueueTests.swift; sourceTree = "<group>"; };
 		126519A706915EF6A552C36D /* IPCContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPCContract.swift; sourceTree = "<group>"; };
 		12978EF6AC1D54BA282486F1 /* InlineAdvancedSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineAdvancedSettings.swift; sourceTree = "<group>"; };
+		1411C64FF77E9D34CFA71265 /* SessionServiceTests+BrowserControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionServiceTests+BrowserControl.swift"; sourceTree = "<group>"; };
 		14A94CD6356D5E7A13A9C7F9 /* ChromeCookieImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeCookieImporter.swift; sourceTree = "<group>"; };
-		150785B3AEE2598ED5427E3D /* idx0.icns.backup-20260322-075809 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "idx0.icns.backup-20260322-075809"; sourceTree = "<group>"; };
+		150785B3AEE2598ED5427E3D /* idx0.icns.backup-20260322-075809 */ = {isa = PBXFileReference; path = "idx0.icns.backup-20260322-075809"; sourceTree = "<group>"; };
 		164D3E27DB793DF6250CB60F /* AppCommandRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCommandRegistryTests.swift; sourceTree = "<group>"; };
 		18F76B8A80EF8F1C875F70AF /* URLRoutingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRoutingService.swift; sourceTree = "<group>"; };
 		1B5460029DE37A1C42C476E9 /* InlineSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineSettingsView.swift; sourceTree = "<group>"; };
@@ -240,6 +246,7 @@
 		2D273EB3EC383B3187985031 /* SidebarResizeHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeHandle.swift; sourceTree = "<group>"; };
 		2F9C7E86A82614D71AC3D0D9 /* AppearanceSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsTab.swift; sourceTree = "<group>"; };
 		3112DCA0B9FFD523792928A9 /* WorkflowModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowModelsTests.swift; sourceTree = "<group>"; };
+		311CD22F7731839DA5785C05 /* NiriTileSpotlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NiriTileSpotlight.swift; sourceTree = "<group>"; };
 		31C148B9BDC30B6C6959E7D7 /* AppCommandRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCommandRegistry.swift; sourceTree = "<group>"; };
 		3289229AFB744281FC5DEFEF /* SessionService+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionService+Utilities.swift"; sourceTree = "<group>"; };
 		32E53938E65ED3647C1B2638 /* NewSessionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewSessionSheet.swift; sourceTree = "<group>"; };
@@ -252,6 +259,7 @@
 		42954794B6E7533BCCF88CC3 /* SessionContainerView+NiriTiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionContainerView+NiriTiles.swift"; sourceTree = "<group>"; };
 		42D76EDDAC2E2645252553FD /* ShellPoolService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellPoolService.swift; sourceTree = "<group>"; };
 		458D8A4C0F0B2D457EA02E7B /* idx0.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = idx0.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		467BBA449474404E3CA394B9 /* BrowserControlConsentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserControlConsentSheet.swift; sourceTree = "<group>"; };
 		47EAE9A64AE413ADDB3582DD /* SessionContainerView+NiriResizeVisualizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionContainerView+NiriResizeVisualizer.swift"; sourceTree = "<group>"; };
 		48ED9438C4AE6FC0DC03E5B6 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		4A8517E677C5C358D38F1205 /* LayoutState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutState.swift; sourceTree = "<group>"; };
@@ -270,6 +278,7 @@
 		5D63C7BC71EBD7E31BF944A3 /* LayoutStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutStateTests.swift; sourceTree = "<group>"; };
 		5EE0EA539A5FA658D27887F8 /* ghostty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ghostty.h; sourceTree = "<group>"; };
 		5F8EAB1EE8E31AFAE297503B /* NiriAppRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NiriAppRegistryTests.swift; sourceTree = "<group>"; };
+		6032736DA955A6FD27D5E81E /* BrowserControlSetupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserControlSetupService.swift; sourceTree = "<group>"; };
 		603A01395B9650650ACB1F9B /* SessionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionService.swift; sourceTree = "<group>"; };
 		60D85B87CD55FD320CDB088F /* ExcalidrawRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcalidrawRuntimeTests.swift; sourceTree = "<group>"; };
 		62F2373B9A7B8F540F8214FD /* ShortcutValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutValidator.swift; sourceTree = "<group>"; };
@@ -278,7 +287,6 @@
 		694CAD837713AD44B34D8010 /* SessionService+RuntimeLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionService+RuntimeLaunch.swift"; sourceTree = "<group>"; };
 		6AA6DAB9923306A0236363D1 /* SessionContainerView+NiriCanvasSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionContainerView+NiriCanvasSurface.swift"; sourceTree = "<group>"; };
 		6EA8C7331AA94A8E5C8F6DCF /* PaneTreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTreeView.swift; sourceTree = "<group>"; };
-		6FA0B16E5CCCBFB1FAA5620C /* NiriTileSpotlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NiriTileSpotlight.swift; sourceTree = "<group>"; };
 		714F5099FB5B255B533B9993 /* SessionSettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionSettingsTab.swift; sourceTree = "<group>"; };
 		72068E526B83803FAFB09694 /* MainWindowSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowSheets.swift; sourceTree = "<group>"; };
 		72CCCD57FC8E6C67F1BC4E0D /* idx0-icon.icon */ = {isa = PBXFileReference; lastKnownFileType = wrapper.icon; path = "idx0-icon.icon"; sourceTree = "<group>"; };
@@ -315,7 +323,6 @@
 		9DC53446A59CB69B5DBD424E /* AgentOutputScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentOutputScanner.swift; sourceTree = "<group>"; };
 		9FF8648BC48369ECB556E182 /* ShortcutRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRegistryTests.swift; sourceTree = "<group>"; };
 		A0F16A8A4931D21AFF9A4EFF /* idx0_GhosttyBridge.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = idx0_GhosttyBridge.c; sourceTree = "<group>"; };
-		A1B2C3D4E5F60718293A4B5C /* SessionService+LaunchPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionService+LaunchPolicy.swift"; sourceTree = "<group>"; };
 		A4BFDA28B8B9F4BC41947EE4 /* BranchNameGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchNameGeneratorTests.swift; sourceTree = "<group>"; };
 		A4CE738D0D42BB63C71A00FE /* VSCodeRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VSCodeRuntime.swift; sourceTree = "<group>"; };
 		A529B4E560D78A441368B39A /* AgentEventRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentEventRouter.swift; sourceTree = "<group>"; };
@@ -325,8 +332,9 @@
 		A96BB4B4F5A3E28F37E9D262 /* ProjectService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectService.swift; sourceTree = "<group>"; };
 		A9D80D208AF87981378D8861 /* WorkflowService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowService.swift; sourceTree = "<group>"; };
 		AE47596354CF7323C58CE3A9 /* BrowserModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserModels.swift; sourceTree = "<group>"; };
+		AEC20DBE17FA2DE2F5E7E140 /* BrowserControlSetupServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserControlSetupServiceTests.swift; sourceTree = "<group>"; };
 		AFB0F063E8279381E6167B64 /* SessionCreationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCreationRequest.swift; sourceTree = "<group>"; };
-		B1B2C3D4E5F60718293A4B5C /* TerminalMonitorServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalMonitorServiceTests.swift; sourceTree = "<group>"; };
+		B2B93A1507BB453BBDD70153 /* OpenCodeRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeRuntime.swift; sourceTree = "<group>"; };
 		B5048750915F84088FED8574 /* idx0.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = idx0.icns; sourceTree = "<group>"; };
 		B5BC04FF0FF385A5961DB941 /* SessionServiceTests+Launch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionServiceTests+Launch.swift"; sourceTree = "<group>"; };
 		BC5385ADD3DADF082CD3893E /* InlineGeneralSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineGeneralSettings.swift; sourceTree = "<group>"; };
@@ -334,10 +342,8 @@
 		BF02E5083B28A0C54E599BF2 /* ShortcutRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRegistry.swift; sourceTree = "<group>"; };
 		C0E869F53140CDC4C857F1C4 /* SessionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionModels.swift; sourceTree = "<group>"; };
 		C154F30A5F338A27AB53712F /* SessionServiceTests+Niri.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionServiceTests+Niri.swift"; sourceTree = "<group>"; };
-		C1B2C3D4E5F60718293A4B5C /* RestoreLaunchQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreLaunchQueueTests.swift; sourceTree = "<group>"; };
 		C27AA169BC08CF6EE14A8627 /* WorkflowRailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowRailView.swift; sourceTree = "<group>"; };
 		C2DF94962EFABB2E7A81F69E /* NiriOnboardingGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NiriOnboardingGate.swift; sourceTree = "<group>"; };
-		C3D4E5F60718293A4B5C6D7E /* OpenCodeRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeRuntime.swift; sourceTree = "<group>"; };
 		C8D0CE8D1993A019F20D0CFD /* idx0-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "idx0-Bridging-Header.h"; sourceTree = "<group>"; };
 		CBE452CDCBD97B412A836AE6 /* InlineSafetySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineSafetySettings.swift; sourceTree = "<group>"; };
 		CC152560147637D6EC0CD35B /* openvscode-build-manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "openvscode-build-manifest.json"; sourceTree = "<group>"; };
@@ -345,17 +351,18 @@
 		CDE12E08D37699A7663BB063 /* SessionContainerView+NiriMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionContainerView+NiriMetrics.swift"; sourceTree = "<group>"; };
 		CF32A5CDE91085A45FAEF298 /* GhosttyTerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalView.swift; sourceTree = "<group>"; };
 		D093665B29003B4CDD1793FD /* SessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStoreTests.swift; sourceTree = "<group>"; };
+		D0DF5DDE163F1A0D142C48A1 /* TerminalMonitorServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalMonitorServiceTests.swift; sourceTree = "<group>"; };
 		D1D4C1C59381DEB755085208 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D217118EDBB72CD44D1B9247 /* CheckpointsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckpointsSheet.swift; sourceTree = "<group>"; };
 		D247FD43F4437A9B3BD963BC /* NiriAppRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NiriAppRegistry.swift; sourceTree = "<group>"; };
 		D24B9DA71E880339383D7D43 /* HandoffComposerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandoffComposerSheet.swift; sourceTree = "<group>"; };
-		D4E5F60718293A4B5C6D7E8F /* OpenCodeRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeRuntimeTests.swift; sourceTree = "<group>"; };
 		D6ED7E9421B0B45E803E9F9D /* FileSystemPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemPaths.swift; sourceTree = "<group>"; };
 		D89C8135090E45DA8C94DBFE /* SessionService+Lifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionService+Lifecycle.swift"; sourceTree = "<group>"; };
 		D8B40C0353C4A178B385EB0D /* FuzzyMatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatchTests.swift; sourceTree = "<group>"; };
 		D9962C2537A206B836AAA1CE /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		D9A3B6B056A35C674DB49A2E /* SessionContainerView+NiriDragResize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionContainerView+NiriDragResize.swift"; sourceTree = "<group>"; };
 		D9AEFE7132B90AF0A032108D /* AppCoordinator+ShortcutCommandDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppCoordinator+ShortcutCommandDispatcher.swift"; sourceTree = "<group>"; };
+		D9D7D0881CD90FDAA7D118A0 /* OpenCodeRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeRuntimeTests.swift; sourceTree = "<group>"; };
 		DAF59ED0F82787D85C955F4E /* ExcalidrawRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcalidrawRuntime.swift; sourceTree = "<group>"; };
 		DB1775F64883C385AC9E7EEA /* WorktreeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeInfo.swift; sourceTree = "<group>"; };
 		DD36B859D9782DE4AFD5826A /* KeyboardSettingsViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardSettingsViews.swift; sourceTree = "<group>"; };
@@ -368,6 +375,7 @@
 		E68FA8BE49E49930255DBBDA /* SessionContainerView+NiriSupportTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionContainerView+NiriSupportTypes.swift"; sourceTree = "<group>"; };
 		E6F8B6A69E321355348D4610 /* SupervisionQueueServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupervisionQueueServiceTests.swift; sourceTree = "<group>"; };
 		E915E2738ADB3CF7EF3C96AC /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GhosttyKit.xcframework; sourceTree = "<group>"; };
+		E9AC133221097B436EBAB1F1 /* SessionService+LaunchPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionService+LaunchPolicy.swift"; sourceTree = "<group>"; };
 		EA71778431F55CCEF74C5BBD /* AppSettingsKeyboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsKeyboardTests.swift; sourceTree = "<group>"; };
 		EAB281CC5B7AD26E420B6787 /* SafetySettingsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafetySettingsTab.swift; sourceTree = "<group>"; };
 		EAEFA3D2F171F4CF5682027F /* BrowserToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserToolbar.swift; sourceTree = "<group>"; };
@@ -447,6 +455,7 @@
 		26AAC074DB4C91C29ACE7E8D /* SessionContainer */ = {
 			isa = PBXGroup;
 			children = (
+				311CD22F7731839DA5785C05 /* NiriTileSpotlight.swift */,
 				0D41A657FCE96AB8403908B5 /* SessionContainerNiriWorkspaceLayout.swift */,
 				297FF569B25ACB8A99CA5CB1 /* SessionContainerView.swift */,
 				FD37B4C15A60B8C9E450BD51 /* SessionContainerView+BrowserSplitResize.swift */,
@@ -458,7 +467,6 @@
 				77D07E1D74241531F78C9443 /* SessionContainerView+NiriItemViews.swift */,
 				CDE12E08D37699A7663BB063 /* SessionContainerView+NiriMetrics.swift */,
 				0913EC98AEA1A5769872F12E /* SessionContainerView+NiriQuickAddToolbar.swift */,
-				6FA0B16E5CCCBFB1FAA5620C /* NiriTileSpotlight.swift */,
 				47EAE9A64AE413ADDB3582DD /* SessionContainerView+NiriResizeVisualizer.swift */,
 				E68FA8BE49E49930255DBBDA /* SessionContainerView+NiriSupportTypes.swift */,
 				42954794B6E7533BCCF88CC3 /* SessionContainerView+NiriTiles.swift */,
@@ -527,9 +535,9 @@
 			isa = PBXGroup;
 			children = (
 				A0153BB7359B4F14866A3A5B /* Excalidraw */,
+				9608E279AE67D4F12B99474B /* OpenCode */,
 				F10EF007191D14CF7D249BA4 /* T3Code */,
 				1194C0592BDF22BD406C09A1 /* VSCode */,
-				F60718293A4B5C6D7E8F9012 /* OpenCode */,
 			);
 			path = Apps;
 			sourceTree = "<group>";
@@ -566,6 +574,7 @@
 		62A63927E1863A15DE054425 /* Browser */ = {
 			isa = PBXGroup;
 			children = (
+				6032736DA955A6FD27D5E81E /* BrowserControlSetupService.swift */,
 				3534C31D8F7EBEEBF48AD2E8 /* BrowserDataStore.swift */,
 				14A94CD6356D5E7A13A9C7F9 /* ChromeCookieImporter.swift */,
 			);
@@ -591,6 +600,14 @@
 				1F14A30AD385DAFB54FC4455 /* idx0Tests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		6E006EF0D3A9444B87A46A4F /* OpenCode */ = {
+			isa = PBXGroup;
+			children = (
+				B2B93A1507BB453BBDD70153 /* OpenCodeRuntime.swift */,
+			);
+			path = OpenCode;
 			sourceTree = "<group>";
 		};
 		741C4D18DB52408CFC522991 /* Frameworks */ = {
@@ -635,6 +652,7 @@
 		8DA838FA53452546A28BDFA6 /* Sheets */ = {
 			isa = PBXGroup;
 			children = (
+				467BBA449474404E3CA394B9 /* BrowserControlConsentSheet.swift */,
 				D217118EDBB72CD44D1B9247 /* CheckpointsSheet.swift */,
 				9CA98693029DF7B53C360C09 /* KeyboardShortcutsSheet.swift */,
 				32E53938E65ED3647C1B2638 /* NewSessionSheet.swift */,
@@ -655,6 +673,14 @@
 				714F5099FB5B255B533B9993 /* SessionSettingsTab.swift */,
 			);
 			path = Tabs;
+			sourceTree = "<group>";
+		};
+		9608E279AE67D4F12B99474B /* OpenCode */ = {
+			isa = PBXGroup;
+			children = (
+				D9D7D0881CD90FDAA7D118A0 /* OpenCodeRuntimeTests.swift */,
+			);
+			path = OpenCode;
 			sourceTree = "<group>";
 		};
 		9683579B0B776409E0F9A98C /* Keyboard */ = {
@@ -784,8 +810,8 @@
 				C0E869F53140CDC4C857F1C4 /* SessionModels.swift */,
 				04A5622E3348C3DBA98663A6 /* SessionRestoreCoordinator.swift */,
 				603A01395B9650650ACB1F9B /* SessionService.swift */,
+				E9AC133221097B436EBAB1F1 /* SessionService+LaunchPolicy.swift */,
 				056B07A95FE3CA67B2B2271D /* SessionService+LayoutPersistence.swift */,
-				A1B2C3D4E5F60718293A4B5C /* SessionService+LaunchPolicy.swift */,
 				D89C8135090E45DA8C94DBFE /* SessionService+Lifecycle.swift */,
 				769DAB2595E31721E2C06C50 /* SessionService+NiriCanvasOps.swift */,
 				694CAD837713AD44B34D8010 /* SessionService+RuntimeLaunch.swift */,
@@ -818,9 +844,9 @@
 			children = (
 				EBBA45F552AB22BE4D13D991 /* Core */,
 				57BBF569C19DB83BFFCF9386 /* Excalidraw */,
+				6E006EF0D3A9444B87A46A4F /* OpenCode */,
 				0848A2A746C74F4F4070941D /* T3Code */,
 				621B3AF26F6F5F6CF82AF166 /* VSCode */,
-				E5F60718293A4B5C6D7E8F90 /* OpenCode */,
 			);
 			path = Apps;
 			sourceTree = "<group>";
@@ -846,14 +872,6 @@
 			path = Commands;
 			sourceTree = "<group>";
 		};
-		E5F60718293A4B5C6D7E8F90 /* OpenCode */ = {
-			isa = PBXGroup;
-			children = (
-				C3D4E5F60718293A4B5C6D7E /* OpenCodeRuntime.swift */,
-			);
-			path = OpenCode;
-			sourceTree = "<group>";
-		};
 		EBBA45F552AB22BE4D13D991 /* Core */ = {
 			isa = PBXGroup;
 			children = (
@@ -876,14 +894,6 @@
 				1F79E05AB6D634F53DE988F5 /* T3CodeRuntimeTests.swift */,
 			);
 			path = T3Code;
-			sourceTree = "<group>";
-		};
-		F60718293A4B5C6D7E8F9012 /* OpenCode */ = {
-			isa = PBXGroup;
-			children = (
-				D4E5F60718293A4B5C6D7E8F /* OpenCodeRuntimeTests.swift */,
-			);
-			path = OpenCode;
 			sourceTree = "<group>";
 		};
 		FA210FBF0BB82335A3ADE7D6 /* idx0 */ = {
@@ -911,22 +921,24 @@
 				EA71778431F55CCEF74C5BBD /* AppSettingsKeyboardTests.swift */,
 				EBE1EAD2776C1DBE09E2DF1B /* AutoCheckpointServiceTests.swift */,
 				A4BFDA28B8B9F4BC41947EE4 /* BranchNameGeneratorTests.swift */,
+				AEC20DBE17FA2DE2F5E7E140 /* BrowserControlSetupServiceTests.swift */,
 				2ABECF80192D5F946ED8666B /* BrowserDataStoreTests.swift */,
-				C1B2C3D4E5F60718293A4B5C /* RestoreLaunchQueueTests.swift */,
 				D8B40C0353C4A178B385EB0D /* FuzzyMatchTests.swift */,
 				90EE0DE10784650DC7094D02 /* GitServiceParsingTests.swift */,
 				5D63C7BC71EBD7E31BF944A3 /* LayoutStateTests.swift */,
 				5F8EAB1EE8E31AFAE297503B /* NiriAppRegistryTests.swift */,
 				922E70866C06A866A454B057 /* NiriOnboardingGateTests.swift */,
 				88326F59CB46BC92265E9EB5 /* PaneNodeTests.swift */,
+				1177D409C8A650B1E7C2195E /* RestoreLaunchQueueTests.swift */,
 				779E0989D99E1DDC0D97FD22 /* SessionModelTests.swift */,
 				5186DB32861A1F5757732E2D /* SessionServiceIntegrationTests.swift */,
 				F7B0FD907F47C273890F14B9 /* SessionServiceTests.swift */,
+				1411C64FF77E9D34CFA71265 /* SessionServiceTests+BrowserControl.swift */,
 				B5BC04FF0FF385A5961DB941 /* SessionServiceTests+Launch.swift */,
 				C154F30A5F338A27AB53712F /* SessionServiceTests+Niri.swift */,
 				D093665B29003B4CDD1793FD /* SessionStoreTests.swift */,
 				E6F8B6A69E321355348D4610 /* SupervisionQueueServiceTests.swift */,
-				B1B2C3D4E5F60718293A4B5C /* TerminalMonitorServiceTests.swift */,
+				D0DF5DDE163F1A0D142C48A1 /* TerminalMonitorServiceTests.swift */,
 				867382630242730813387E6E /* TerminalThemeTests.swift */,
 				3112DCA0B9FFD523792928A9 /* WorkflowModelsTests.swift */,
 				BEA146F38A368A5A2BBAD9E0 /* WorkflowServiceTests.swift */,
@@ -1039,17 +1051,20 @@
 				6266D5D37F7E1D7FF596B10D /* AppSettingsKeyboardTests.swift in Sources */,
 				8323E5B818F6AF91B355CA11 /* AutoCheckpointServiceTests.swift in Sources */,
 				22B1B9E0EA022D8228A26BC9 /* BranchNameGeneratorTests.swift in Sources */,
+				732B5CE5894B8AAB395D5A70 /* BrowserControlSetupServiceTests.swift in Sources */,
 				E39960209C6BA428A922B5E0 /* BrowserDataStoreTests.swift in Sources */,
-				C3F4A1B2C3D4E5F60718293A /* RestoreLaunchQueueTests.swift in Sources */,
 				066EDA0406A00EAD947B9D4F /* ExcalidrawRuntimeTests.swift in Sources */,
 				05FDC6EF2EA1379932BEC9FA /* FuzzyMatchTests.swift in Sources */,
 				9F6995C2F654B9422548C148 /* GitServiceParsingTests.swift in Sources */,
 				E8ADEE219025F24923A990A7 /* LayoutStateTests.swift in Sources */,
 				D0A0A761157727FDFB96C9C1 /* NiriAppRegistryTests.swift in Sources */,
 				0A82A6B83B1252493812FBE4 /* NiriOnboardingGateTests.swift in Sources */,
+				B979DB37F81B4C1D82176614 /* OpenCodeRuntimeTests.swift in Sources */,
 				9B8617148268B082058F92FE /* PaneNodeTests.swift in Sources */,
+				B5CFE5F6459F81A8666CB315 /* RestoreLaunchQueueTests.swift in Sources */,
 				458A0057B76598B3D58CD0F3 /* SessionModelTests.swift in Sources */,
 				C4DD853D2845C83830C3BCB6 /* SessionServiceIntegrationTests.swift in Sources */,
+				4116D46FD4291623E6BDDDBD /* SessionServiceTests+BrowserControl.swift in Sources */,
 				553B8C11C5536D6292D03BD5 /* SessionServiceTests+Launch.swift in Sources */,
 				41092C03A899796A0711FC42 /* SessionServiceTests+Niri.swift in Sources */,
 				D41E12F6A33CC51A1F4E265C /* SessionServiceTests.swift in Sources */,
@@ -1057,8 +1072,7 @@
 				E72847AEEF99AC4FF921A86E /* ShortcutRegistryTests.swift in Sources */,
 				AFE3451E6F9A754B645F9435 /* SupervisionQueueServiceTests.swift in Sources */,
 				58987615D32B830F852135E5 /* T3CodeRuntimeTests.swift in Sources */,
-				B2F4A1B2C3D4E5F60718293A /* TerminalMonitorServiceTests.swift in Sources */,
-				B2C3D4E5F60718293A4B5C6D /* OpenCodeRuntimeTests.swift in Sources */,
+				5884A8FBF5C47453B469980A /* TerminalMonitorServiceTests.swift in Sources */,
 				036A444E148F29E56A156F65 /* TerminalThemeTests.swift in Sources */,
 				6D5F242BF42126B4C201A625 /* VSCodeRuntimeTests.swift in Sources */,
 				E2B377CCEA8EC06AC24CFDE8 /* WorkflowModelsTests.swift in Sources */,
@@ -1083,6 +1097,8 @@
 				E75A4BFE43D605C454B38907 /* AutoCheckpointService.swift in Sources */,
 				494C890E5589D1B119EBD88A /* BootstrapCoordinator.swift in Sources */,
 				686A29E7530965CAB3B0C7AD /* BranchNameGenerator.swift in Sources */,
+				1968EC9A62A06303633848F5 /* BrowserControlConsentSheet.swift in Sources */,
+				AEB9F9C48C035287145DA1A0 /* BrowserControlSetupService.swift in Sources */,
 				D9D6D3565238EB7C53461C32 /* BrowserDataStore.swift in Sources */,
 				CA2FF80394C68F4A1BB2F4B8 /* BrowserModels.swift in Sources */,
 				07EBB1F78F1F6C061A36BDC0 /* BrowserToolbar.swift in Sources */,
@@ -1127,6 +1143,8 @@
 				BF15EBA18655AF1B536F5ED5 /* NiriAppRegistry.swift in Sources */,
 				BC153A7DE0D6E4176DA9A38A /* NiriOnboardingGate.swift in Sources */,
 				D2CA90D9F216BA9D486B7DFB /* NiriOnboardingSheet.swift in Sources */,
+				EEB3852F18CB4DA5E93C2A3F /* NiriTileSpotlight.swift in Sources */,
+				CA1FC091D045423FB05535BF /* OpenCodeRuntime.swift in Sources */,
 				96CB8BB3138CE08A017A0073 /* PaneNode.swift in Sources */,
 				48CD82F3363A82E058277D62 /* PaneTreeView.swift in Sources */,
 				D83F7A3DA959C9615086FCE5 /* ProcessRunner.swift in Sources */,
@@ -1147,7 +1165,6 @@
 				3F370869C5D7E4FFB73FE800 /* SessionContainerView+NiriItemViews.swift in Sources */,
 				8673AB3379194493EB7BAE19 /* SessionContainerView+NiriMetrics.swift in Sources */,
 				FB60AE91F3B4A3DB36E008F3 /* SessionContainerView+NiriQuickAddToolbar.swift in Sources */,
-				2AE9DE55597E704B7B99B0EF /* NiriTileSpotlight.swift in Sources */,
 				65172983E398238D0E4AFD07 /* SessionContainerView+NiriResizeVisualizer.swift in Sources */,
 				08DD928F54822DCB46AAC44C /* SessionContainerView+NiriSupportTypes.swift in Sources */,
 				12E88F91FCDA7BC82CEF2C57 /* SessionContainerView+NiriTiles.swift in Sources */,
@@ -1160,8 +1177,8 @@
 				8554E9BCA4F511D4B5D570A5 /* SessionLauncher.swift in Sources */,
 				26FA772FB59719EE96B56CD4 /* SessionModels.swift in Sources */,
 				3EB35636AF5FF0DC4C2DF8F9 /* SessionRestoreCoordinator.swift in Sources */,
+				7AAB313E7318042DD6A0131D /* SessionService+LaunchPolicy.swift in Sources */,
 				35036CCAD106D88964E5BDF2 /* SessionService+LayoutPersistence.swift in Sources */,
-				A1F4A1B2C3D4E5F60718293A /* SessionService+LaunchPolicy.swift in Sources */,
 				A8121E3B671B6E1F0F5CC1CB /* SessionService+Lifecycle.swift in Sources */,
 				131CEB0DEE775C1C144BFDAB /* SessionService+NiriCanvasOps.swift in Sources */,
 				A907F0A7793223D7D2922FFC /* SessionService+RuntimeLaunch.swift in Sources */,
@@ -1184,7 +1201,6 @@
 				8EBD5438089ADC23B4BB26F1 /* SidebarResizeHandle.swift in Sources */,
 				860E1AE5892CF200352256FC /* SupervisionQueueService.swift in Sources */,
 				C4BF4ED638BB64C3380B9C1F /* T3CodeRuntime.swift in Sources */,
-				A2B3C4D5E6F708192A3B4C5D /* OpenCodeRuntime.swift in Sources */,
 				893B94051D5F59B2413D91BC /* TabBarOverlay.swift in Sources */,
 				64447C377FF57F3FD4ED4CC9 /* TerminalMonitorService.swift in Sources */,
 				63CB95EF0E4145A598612B03 /* TerminalSessionController.swift in Sources */,
@@ -1227,26 +1243,18 @@
 		0A80E460BD4ADD08E0262271 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "idx0-icon";
-				AUTOMATION_APPLE_EVENTS = NO;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 6RFK6NMTV7;
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
-				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
-				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
-				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
-				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
-				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\".\"",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)",
+				);
 				INFOPLIST_KEY_CFBundleDisplayName = IDX0;
 				INFOPLIST_KEY_CFBundleIconFile = idx0.icns;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -1255,7 +1263,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.0.12;
+				MARKETING_VERSION = 0.0.1;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -1273,12 +1281,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.gal.idx0;
 				PRODUCT_NAME = idx0;
-				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
-				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
-				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
-				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
-				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
-				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "idx0-Bridging-Header.h";
 			};
@@ -1287,26 +1289,18 @@
 		113FCC8CAF125E40DFB30950 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "idx0-icon";
-				AUTOMATION_APPLE_EVENTS = NO;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 6RFK6NMTV7;
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
-				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
-				ENABLE_RESOURCE_ACCESS_CAMERA = NO;
-				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
-				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
-				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\".\"",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "$(SRCROOT)";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)",
+				);
 				INFOPLIST_KEY_CFBundleDisplayName = IDX0;
 				INFOPLIST_KEY_CFBundleIconFile = idx0.icns;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
@@ -1315,7 +1309,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.0.12;
+				MARKETING_VERSION = 0.0.1;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -1333,12 +1327,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.gal.idx0;
 				PRODUCT_NAME = idx0;
-				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
-				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
-				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
-				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
-				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
-				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
 				SDKROOT = macosx;
 				SWIFT_OBJC_BRIDGING_HEADER = "idx0-Bridging-Header.h";
 			};
@@ -1404,10 +1392,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 6RFK6NMTV7;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1488,10 +1473,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 6RFK6NMTV7;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/idx0/App/AppCoordinator+ShortcutCommandDispatcher.swift
+++ b/idx0/App/AppCoordinator+ShortcutCommandDispatcher.swift
@@ -139,7 +139,7 @@ extension AppCoordinator {
     ) -> Bool? {
         switch action {
         case .openClipboardURL:
-            return sessionService.openClipboardURLInSplit(for: selectedSessionID)
+            return sessionService.requestOpenClipboardURLInSplit(for: selectedSessionID)
         case .newTab:
             guard let selectedSessionID else { return false }
             _ = sessionService.createTab(in: selectedSessionID)
@@ -193,7 +193,7 @@ extension AppCoordinator {
             return true
         case .toggleBrowserSplit:
             guard let selectedSessionID else { return false }
-            sessionService.toggleBrowserSplit(for: selectedSessionID)
+            sessionService.requestToggleBrowserSplit(for: selectedSessionID)
             return true
         default:
             return nil
@@ -226,7 +226,7 @@ extension AppCoordinator {
             return true
         case .niriAddBrowserTile:
             guard niriEnabled, let selectedSessionID else { return false }
-            _ = sessionService.niriAddBrowserRight(in: selectedSessionID)
+            _ = sessionService.requestAddNiriBrowserTile(in: selectedSessionID)
             return true
         case .niriOpenAddTileMenu:
             return requestNiriAddTileMenu(for: selectedSessionID)

--- a/idx0/App/AppSettings.swift
+++ b/idx0/App/AppSettings.swift
@@ -31,6 +31,12 @@ enum ExternalLinkRouting: String, Codable, CaseIterable {
     }
 }
 
+enum BrowserControlConsent: String, Codable, CaseIterable {
+    case undecided
+    case enabled
+    case declined
+}
+
 enum NewSessionBehavior: String, Codable, CaseIterable {
     case quick
     case structured
@@ -262,7 +268,7 @@ struct NiriSettings: Codable, Equatable {
 }
 
 struct AppSettings: Codable, Equatable {
-    static let schemaVersion = 7
+    static let schemaVersion = 8
 
     var schemaVersion: Int
     var sidebarVisible: Bool
@@ -275,6 +281,7 @@ struct AppSettings: Codable, Equatable {
     var defaultSandboxProfile: SandboxProfile
     var defaultNetworkPolicy: NetworkPolicy
     var externalLinkRouting: ExternalLinkRouting
+    var browserControlConsent: BrowserControlConsent
     var browserSplitDefaultSide: SplitSide
     var restoreBehavior: RestoreBehavior
     var cleanupOnClose: Bool
@@ -302,6 +309,7 @@ struct AppSettings: Codable, Equatable {
         defaultSandboxProfile: SandboxProfile = .fullAccess,
         defaultNetworkPolicy: NetworkPolicy = .inherited,
         externalLinkRouting: ExternalLinkRouting = .defaultBrowser,
+        browserControlConsent: BrowserControlConsent = .undecided,
         browserSplitDefaultSide: SplitSide = .right,
         restoreBehavior: RestoreBehavior = .relaunchAllSessions,
         cleanupOnClose: Bool = false,
@@ -328,6 +336,7 @@ struct AppSettings: Codable, Equatable {
         self.defaultSandboxProfile = defaultSandboxProfile
         self.defaultNetworkPolicy = defaultNetworkPolicy
         self.externalLinkRouting = externalLinkRouting
+        self.browserControlConsent = browserControlConsent
         self.browserSplitDefaultSide = browserSplitDefaultSide
         self.restoreBehavior = restoreBehavior
         self.cleanupOnClose = cleanupOnClose
@@ -357,6 +366,7 @@ struct AppSettings: Codable, Equatable {
         case defaultSandboxProfile
         case defaultNetworkPolicy
         case externalLinkRouting
+        case browserControlConsent
         case browserSplitDefaultSide
         case restoreBehavior
         case cleanupOnClose
@@ -393,6 +403,7 @@ struct AppSettings: Codable, Equatable {
             externalLinkRouting = openLinks ? .defaultBrowser : .embeddedBrowser
         }
 
+        browserControlConsent = try container.decodeIfPresent(BrowserControlConsent.self, forKey: .browserControlConsent) ?? .undecided
         browserSplitDefaultSide = try container.decodeIfPresent(SplitSide.self, forKey: .browserSplitDefaultSide) ?? .right
         restoreBehavior = try container.decodeIfPresent(RestoreBehavior.self, forKey: .restoreBehavior) ?? .relaunchAllSessions
         cleanupOnClose = try container.decodeIfPresent(Bool.self, forKey: .cleanupOnClose) ?? false
@@ -422,6 +433,7 @@ struct AppSettings: Codable, Equatable {
         try container.encode(defaultSandboxProfile, forKey: .defaultSandboxProfile)
         try container.encode(defaultNetworkPolicy, forKey: .defaultNetworkPolicy)
         try container.encode(externalLinkRouting, forKey: .externalLinkRouting)
+        try container.encode(browserControlConsent, forKey: .browserControlConsent)
         try container.encode(browserSplitDefaultSide, forKey: .browserSplitDefaultSide)
         try container.encode(restoreBehavior, forKey: .restoreBehavior)
         try container.encode(cleanupOnClose, forKey: .cleanupOnClose)

--- a/idx0/Apps/OpenCode/OpenCodeRuntime.swift
+++ b/idx0/Apps/OpenCode/OpenCodeRuntime.swift
@@ -75,6 +75,7 @@ final class OpenCodeStateSnapshotManager {
         fileManager: FileManager = .default
     ) throws -> OpenCodeSessionState {
         try paths.ensureBaseDirectories(fileManager: fileManager)
+        try upsertIDX0BrowserMCPConfigIfAvailable(paths: paths, fileManager: fileManager)
         return OpenCodeSessionState(
             xdgConfigHome: paths.xdgConfigHomeDirectory,
             xdgDataHome: paths.xdgDataHomeDirectory,
@@ -88,6 +89,116 @@ final class OpenCodeStateSnapshotManager {
         fileManager: FileManager = .default
     ) {
         try? fileManager.removeItem(at: paths.sessionDirectory)
+    }
+
+    private func upsertIDX0BrowserMCPConfigIfAvailable(
+        paths: OpenCodeRuntimePaths,
+        fileManager: FileManager
+    ) throws {
+        let idx0Root = paths.rootDirectory.deletingLastPathComponent()
+        let wrapperScriptURL = BrowserControlSetupService.wrapperScriptURL(appSupportDirectory: idx0Root)
+        guard fileManager.isExecutableFile(atPath: wrapperScriptURL.path) else { return }
+
+        let opencodeConfigDirectoryURL = paths.xdgConfigHomeDirectory
+            .appendingPathComponent("opencode", isDirectory: true)
+        let opencodeConfigURL = opencodeConfigDirectoryURL
+            .appendingPathComponent("opencode.json", isDirectory: false)
+
+        try fileManager.createDirectory(at: opencodeConfigDirectoryURL, withIntermediateDirectories: true)
+
+        var root: [String: Any] = [:]
+        if fileManager.fileExists(atPath: opencodeConfigURL.path) {
+            let data = try Data(contentsOf: opencodeConfigURL)
+            let text = String(decoding: data, as: UTF8.self)
+            let stripped = stripJSONComments(from: text)
+            guard let parsedData = stripped.data(using: .utf8),
+                  let parsed = try JSONSerialization.jsonObject(with: parsedData) as? [String: Any]
+            else {
+                Logger.error("Skipping OpenCode MCP merge: existing opencode.json is invalid.")
+                return
+            }
+            root = parsed
+        }
+
+        if root["$schema"] == nil {
+            root["$schema"] = "https://opencode.ai/config.json"
+        }
+
+        var mcp = root["mcp"] as? [String: Any] ?? [:]
+        mcp[BrowserControlSetupService.mcpServerName] = [
+            "type": "local",
+            "command": [wrapperScriptURL.path],
+            "enabled": true,
+        ]
+        root["mcp"] = mcp
+
+        let encoded = try JSONSerialization.data(
+            withJSONObject: root,
+            options: [.prettyPrinted, .sortedKeys]
+        ) + Data([0x0A])
+        try encoded.write(to: opencodeConfigURL, options: .atomic)
+    }
+
+    private func stripJSONComments(from text: String) -> String {
+        var output = String()
+        var index = text.startIndex
+        var isInString = false
+        var isEscaped = false
+
+        while index < text.endIndex {
+            let character = text[index]
+
+            if isInString {
+                output.append(character)
+                if isEscaped {
+                    isEscaped = false
+                } else if character == "\\" {
+                    isEscaped = true
+                } else if character == "\"" {
+                    isInString = false
+                }
+                index = text.index(after: index)
+                continue
+            }
+
+            if character == "\"" {
+                isInString = true
+                output.append(character)
+                index = text.index(after: index)
+                continue
+            }
+
+            if character == "/" {
+                let nextIndex = text.index(after: index)
+                if nextIndex < text.endIndex {
+                    let nextCharacter = text[nextIndex]
+                    if nextCharacter == "/" {
+                        index = text.index(after: nextIndex)
+                        while index < text.endIndex, text[index] != "\n" {
+                            index = text.index(after: index)
+                        }
+                        continue
+                    }
+                    if nextCharacter == "*" {
+                        index = text.index(after: nextIndex)
+                        while index < text.endIndex {
+                            let candidateEnd = text.index(after: index)
+                            if text[index] == "*", candidateEnd < text.endIndex, text[candidateEnd] == "/" {
+                                index = text.index(after: candidateEnd)
+                                break
+                            }
+                            index = text.index(after: index)
+                        }
+                        continue
+                    }
+                }
+            }
+
+            output.append(character)
+            index = text.index(after: index)
+        }
+
+        return output
     }
 }
 

--- a/idx0/Apps/T3Code/T3CodeRuntime.swift
+++ b/idx0/Apps/T3Code/T3CodeRuntime.swift
@@ -555,6 +555,7 @@ final class T3TileController: ObservableObject, NiriAppTileRuntimeControlling {
     private let snapshotManager: T3StateSnapshotManager
     private let manifestProvider: () -> T3BuildManifest
     private let paths: T3RuntimePaths
+    private let browserControlEnabled: Bool
 
     private let readinessIntervalNanoseconds: UInt64 = 250_000_000
     private let readinessTimeoutSeconds: TimeInterval = 20
@@ -579,7 +580,8 @@ final class T3TileController: ObservableObject, NiriAppTileRuntimeControlling {
         launchDirectoryProvider: @escaping () -> String?,
         buildCoordinator: T3BuildCoordinator,
         snapshotManager: T3StateSnapshotManager,
-        manifestProvider: @escaping () -> T3BuildManifest = { T3BuildManifest.loadFromBundle() }
+        manifestProvider: @escaping () -> T3BuildManifest = { T3BuildManifest.loadFromBundle() },
+        browserControlEnabled: Bool = false
     ) {
         self.sessionID = sessionID
         self.itemID = itemID
@@ -588,6 +590,7 @@ final class T3TileController: ObservableObject, NiriAppTileRuntimeControlling {
         self.snapshotManager = snapshotManager
         self.manifestProvider = manifestProvider
         self.paths = T3RuntimePaths(sessionID: sessionID)
+        self.browserControlEnabled = browserControlEnabled
 
         let configuration = WKWebViewConfiguration()
         configuration.defaultWebpagePreferences.allowsContentJavaScript = true
@@ -708,6 +711,11 @@ final class T3TileController: ObservableObject, NiriAppTileRuntimeControlling {
             stateDirectory: stateDirectory,
             workingDirectory: launchDirectoryProvider() ?? FileManager.default.homeDirectoryForCurrentUser.path
         )
+        if browserControlEnabled {
+            appendRuntimeLog(
+                "browser control enabled via MCP server '\(BrowserControlSetupService.mcpServerName)' for globally configured CLIs"
+            )
+        }
 
         let ready = await waitForServerReady(port: port)
         guard ready else {

--- a/idx0/Services/Browser/BrowserControlSetupService.swift
+++ b/idx0/Services/Browser/BrowserControlSetupService.swift
@@ -1,0 +1,339 @@
+import Foundation
+
+protocol BrowserControlSetupServicing: Sendable {
+    func provision(force: Bool, preferredBrowserAppURL: URL?) async throws -> BrowserControlSetupResult
+}
+
+struct BrowserControlSetupResult: Equatable, Sendable {
+    let serverName: String
+    let wrapperCommand: [String]
+    let wrapperScriptPath: String
+    let chromiumProfilePath: String
+    let browserExecutablePath: String?
+    let configuredToolIDs: [String]
+    let skippedToolIDs: [String]
+}
+
+enum BrowserControlSetupError: LocalizedError {
+    case npmInstallFailed(command: String, output: String)
+    case playwrightMCPBinaryMissing(String)
+    case wrapperWriteFailed(String)
+    case cliConfigurationFailed(toolID: String, command: String, output: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .npmInstallFailed(let command, let output):
+            return "Browser control install failed while running `\(command)`: \(output)"
+        case .playwrightMCPBinaryMissing(let path):
+            return "Browser control install completed but Playwright MCP binary was not found at \(path)."
+        case .wrapperWriteFailed(let message):
+            return "Failed to write browser control launch wrapper: \(message)"
+        case .cliConfigurationFailed(let toolID, let command, let output):
+            return "Configured \(toolID), but MCP registration failed (`\(command)`): \(output)"
+        }
+    }
+}
+
+private struct BrowserControlSetupManifest: Codable {
+    let version: Int
+    let playwrightPackage: String
+    let browserExecutablePath: String?
+    let configuredToolIDs: [String]
+    let skippedToolIDs: [String]
+    let updatedAt: Date
+}
+
+actor BrowserControlSetupService: BrowserControlSetupServicing {
+    static let mcpServerName = "idx0-browser"
+    static let pinnedPlaywrightMCPPackage = "@playwright/mcp@0.0.68"
+    static let manifestVersion = 1
+    static let wrapperScriptName = "idx0-browser-mcp"
+
+    private let appSupportDirectory: URL
+    private let processRunner: any ProcessRunnerProtocol
+    private let fileManager: FileManager
+    private let discoveredToolsProvider: () -> [VibeCLITool]
+
+    init(
+        appSupportDirectory: URL,
+        processRunner: any ProcessRunnerProtocol = ProcessRunner(),
+        fileManager: FileManager = .default,
+        discoveredToolsProvider: @escaping () -> [VibeCLITool] = {
+            VibeCLIDiscoveryService().discoverInstalledTools()
+        }
+    ) {
+        self.appSupportDirectory = appSupportDirectory
+        self.processRunner = processRunner
+        self.fileManager = fileManager
+        self.discoveredToolsProvider = discoveredToolsProvider
+    }
+
+    static func installRootURL(appSupportDirectory: URL) -> URL {
+        appSupportDirectory.appendingPathComponent("browser-control", isDirectory: true)
+    }
+
+    static func wrapperScriptURL(appSupportDirectory: URL) -> URL {
+        installRootURL(appSupportDirectory: appSupportDirectory)
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent(wrapperScriptName, isDirectory: false)
+    }
+
+    static func chromiumProfileDirectoryURL(appSupportDirectory: URL) -> URL {
+        installRootURL(appSupportDirectory: appSupportDirectory)
+            .appendingPathComponent("chromium-profile", isDirectory: true)
+    }
+
+    private static func manifestURL(appSupportDirectory: URL) -> URL {
+        installRootURL(appSupportDirectory: appSupportDirectory)
+            .appendingPathComponent("manifest.json", isDirectory: false)
+    }
+
+    func provision(force: Bool, preferredBrowserAppURL: URL?) async throws -> BrowserControlSetupResult {
+        let installRootURL = Self.installRootURL(appSupportDirectory: appSupportDirectory)
+        let wrapperScriptURL = Self.wrapperScriptURL(appSupportDirectory: appSupportDirectory)
+        let chromiumProfileDirectoryURL = Self.chromiumProfileDirectoryURL(appSupportDirectory: appSupportDirectory)
+        let manifestURL = Self.manifestURL(appSupportDirectory: appSupportDirectory)
+        let playwrightMCPBinaryURL = installRootURL
+            .appendingPathComponent("node_modules", isDirectory: true)
+            .appendingPathComponent(".bin", isDirectory: true)
+            .appendingPathComponent("playwright-mcp", isDirectory: false)
+
+        if !force,
+           let manifest = loadManifest(at: manifestURL),
+           manifest.version == Self.manifestVersion,
+           manifest.playwrightPackage == Self.pinnedPlaywrightMCPPackage,
+           fileManager.isExecutableFile(atPath: wrapperScriptURL.path),
+           fileManager.isExecutableFile(atPath: playwrightMCPBinaryURL.path),
+           fileManager.fileExists(atPath: chromiumProfileDirectoryURL.path) {
+            return BrowserControlSetupResult(
+                serverName: Self.mcpServerName,
+                wrapperCommand: [wrapperScriptURL.path],
+                wrapperScriptPath: wrapperScriptURL.path,
+                chromiumProfilePath: chromiumProfileDirectoryURL.path,
+                browserExecutablePath: manifest.browserExecutablePath,
+                configuredToolIDs: manifest.configuredToolIDs,
+                skippedToolIDs: manifest.skippedToolIDs
+            )
+        }
+
+        try fileManager.createDirectory(at: installRootURL, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: wrapperScriptURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: chromiumProfileDirectoryURL, withIntermediateDirectories: true)
+
+        try await installPlaywrightMCP(to: installRootURL)
+
+        guard fileManager.isExecutableFile(atPath: playwrightMCPBinaryURL.path) else {
+            throw BrowserControlSetupError.playwrightMCPBinaryMissing(playwrightMCPBinaryURL.path)
+        }
+
+        let browserExecutablePath = resolveChromiumExecutablePath(appBundleURL: preferredBrowserAppURL)
+        try writeWrapperScript(
+            wrapperScriptURL: wrapperScriptURL,
+            mcpBinaryURL: playwrightMCPBinaryURL,
+            chromiumProfileDirectoryURL: chromiumProfileDirectoryURL,
+            browserExecutablePath: browserExecutablePath
+        )
+
+        let (configuredToolIDs, skippedToolIDs) = try await configureSupportedCLIs(wrapperScriptURL: wrapperScriptURL)
+
+        let manifest = BrowserControlSetupManifest(
+            version: Self.manifestVersion,
+            playwrightPackage: Self.pinnedPlaywrightMCPPackage,
+            browserExecutablePath: browserExecutablePath,
+            configuredToolIDs: configuredToolIDs,
+            skippedToolIDs: skippedToolIDs,
+            updatedAt: Date()
+        )
+        let manifestData = try JSONEncoder.prettyPrintedSorted().encode(manifest)
+        try manifestData.write(to: manifestURL, options: .atomic)
+
+        return BrowserControlSetupResult(
+            serverName: Self.mcpServerName,
+            wrapperCommand: [wrapperScriptURL.path],
+            wrapperScriptPath: wrapperScriptURL.path,
+            chromiumProfilePath: chromiumProfileDirectoryURL.path,
+            browserExecutablePath: browserExecutablePath,
+            configuredToolIDs: configuredToolIDs,
+            skippedToolIDs: skippedToolIDs
+        )
+    }
+
+    private func installPlaywrightMCP(to installRootURL: URL) async throws {
+        let installArguments = [
+            "npm",
+            "install",
+            "--prefix", installRootURL.path,
+            "--no-audit",
+            "--no-fund",
+            "--loglevel", "error",
+            Self.pinnedPlaywrightMCPPackage,
+        ]
+        let result = try await processRunner.run(
+            executable: "/usr/bin/env",
+            arguments: installArguments,
+            currentDirectory: nil
+        )
+        guard result.exitCode == 0 else {
+            throw BrowserControlSetupError.npmInstallFailed(
+                command: (["/usr/bin/env"] + installArguments).joined(separator: " "),
+                output: combinedOutput(stdout: result.stdout, stderr: result.stderr)
+            )
+        }
+    }
+
+    private func writeWrapperScript(
+        wrapperScriptURL: URL,
+        mcpBinaryURL: URL,
+        chromiumProfileDirectoryURL: URL,
+        browserExecutablePath: String?
+    ) throws {
+        let browserValue = browserExecutablePath ?? ""
+        let script = """
+        #!/bin/bash
+        set -euo pipefail
+
+        MCP_BIN=\(shellQuote(mcpBinaryURL.path))
+        PROFILE_DIR=\(shellQuote(chromiumProfileDirectoryURL.path))
+        BROWSER_EXECUTABLE=\(shellQuote(browserValue))
+
+        DEFAULT_ARGS=("--user-data-dir=${PROFILE_DIR}")
+        if [[ -n "${BROWSER_EXECUTABLE}" ]]; then
+          DEFAULT_ARGS+=("--browser=chrome" "--executable-path=${BROWSER_EXECUTABLE}")
+        fi
+
+        exec "${MCP_BIN}" "${DEFAULT_ARGS[@]}" "$@"
+        """
+
+        do {
+            try script.write(to: wrapperScriptURL, atomically: true, encoding: .utf8)
+            try fileManager.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: wrapperScriptURL.path
+            )
+        } catch {
+            throw BrowserControlSetupError.wrapperWriteFailed(error.localizedDescription)
+        }
+    }
+
+    private func configureSupportedCLIs(wrapperScriptURL: URL) async throws -> (configured: [String], skipped: [String]) {
+        let discoveredByID = Dictionary(
+            uniqueKeysWithValues: discoveredToolsProvider().map { ($0.id, $0) }
+        )
+
+        var configured: [String] = []
+        var skipped: [String] = []
+
+        for toolID in ["codex", "claude", "gemini-cli"] {
+            guard let tool = discoveredByID[toolID],
+                  tool.isInstalled,
+                  let executablePath = tool.resolvedPath else {
+                skipped.append(toolID)
+                continue
+            }
+
+            let removeArguments = mcpRemoveArguments(for: toolID, serverName: Self.mcpServerName)
+            let removeResult = try await processRunner.run(
+                executable: executablePath,
+                arguments: removeArguments,
+                currentDirectory: nil
+            )
+            _ = removeResult
+
+            let addArguments = mcpAddArguments(
+                for: toolID,
+                serverName: Self.mcpServerName,
+                wrapperScriptPath: wrapperScriptURL.path
+            )
+            let addResult = try await processRunner.run(
+                executable: executablePath,
+                arguments: addArguments,
+                currentDirectory: nil
+            )
+            guard addResult.exitCode == 0 else {
+                throw BrowserControlSetupError.cliConfigurationFailed(
+                    toolID: toolID,
+                    command: ([executablePath] + addArguments).joined(separator: " "),
+                    output: combinedOutput(stdout: addResult.stdout, stderr: addResult.stderr)
+                )
+            }
+            configured.append(toolID)
+        }
+
+        return (configured.sorted(), skipped.sorted())
+    }
+
+    private func loadManifest(at url: URL) -> BrowserControlSetupManifest? {
+        guard fileManager.fileExists(atPath: url.path),
+              let data = try? Data(contentsOf: url) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(BrowserControlSetupManifest.self, from: data)
+    }
+
+    private func resolveChromiumExecutablePath(appBundleURL: URL?) -> String? {
+        guard let appBundleURL else { return nil }
+        let macOSDirectoryURL = appBundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("MacOS", isDirectory: true)
+        guard let candidates = try? fileManager.contentsOfDirectory(
+            at: macOSDirectoryURL,
+            includingPropertiesForKeys: [.isRegularFileKey, .isExecutableKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+
+        for candidate in candidates.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
+            if fileManager.isExecutableFile(atPath: candidate.path) {
+                return candidate.path
+            }
+        }
+        return nil
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        let escaped = value.replacingOccurrences(of: "'", with: "'\"'\"'")
+        return "'\(escaped)'"
+    }
+
+    private func combinedOutput(stdout: String, stderr: String) -> String {
+        let merged = [stderr.trimmingCharacters(in: .whitespacesAndNewlines), stdout.trimmingCharacters(in: .whitespacesAndNewlines)]
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        return merged.isEmpty ? "No command output." : merged
+    }
+
+    private func mcpRemoveArguments(for toolID: String, serverName: String) -> [String] {
+        switch toolID {
+        case "codex":
+            return ["mcp", "remove", serverName]
+        case "claude":
+            return ["mcp", "remove", "--scope", "user", serverName]
+        case "gemini-cli":
+            return ["mcp", "remove", "--scope", "user", serverName]
+        default:
+            return ["mcp", "remove", serverName]
+        }
+    }
+
+    private func mcpAddArguments(for toolID: String, serverName: String, wrapperScriptPath: String) -> [String] {
+        switch toolID {
+        case "codex":
+            return ["mcp", "add", serverName, "--", wrapperScriptPath]
+        case "claude":
+            return ["mcp", "add", "--scope", "user", serverName, "--", wrapperScriptPath]
+        case "gemini-cli":
+            return ["mcp", "add", "--scope", "user", serverName, wrapperScriptPath]
+        default:
+            return ["mcp", "add", serverName, wrapperScriptPath]
+        }
+    }
+}
+
+private extension JSONEncoder {
+    static func prettyPrintedSorted() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }
+}

--- a/idx0/Services/Session/SessionModels.swift
+++ b/idx0/Services/Session/SessionModels.swift
@@ -26,6 +26,35 @@ struct WorktreeInspectorRequest: Identifiable {
     let repoPath: String
 }
 
+enum BrowserOpenIntent: Equatable {
+    case toggleBrowserSplit(sessionID: UUID)
+    case openURLInSplit(url: URL, sessionID: UUID)
+    case addNiriBrowserTile(sessionID: UUID)
+}
+
+enum BrowserControlConsentPromptMode: Equatable {
+    case firstUse
+    case settingsEnable
+    case settingsRerun
+}
+
+struct BrowserControlConsentPrompt: Identifiable, Equatable {
+    let id = UUID()
+    var mode: BrowserControlConsentPromptMode
+    var isInstalling: Bool
+    var setupErrorMessage: String?
+
+    init(
+        mode: BrowserControlConsentPromptMode,
+        isInstalling: Bool = false,
+        setupErrorMessage: String? = nil
+    ) {
+        self.mode = mode
+        self.isInstalling = isInstalling
+        self.setupErrorMessage = setupErrorMessage
+    }
+}
+
 struct ProjectSessionSection: Identifiable {
     let group: ProjectGroup
     let sessions: [Session]

--- a/idx0/Services/Session/SessionService+SessionOps.swift
+++ b/idx0/Services/Session/SessionService+SessionOps.swift
@@ -275,7 +275,8 @@ extension SessionService {
                 self?.launchDirectory(for: sessionID) ?? FileManager.default.homeDirectoryForCurrentUser.path
             },
             buildCoordinator: t3BuildCoordinator,
-            snapshotManager: t3SnapshotManager
+            snapshotManager: t3SnapshotManager,
+            browserControlEnabled: settings.browserControlConsent == .enabled
         )
     }
 
@@ -383,6 +384,139 @@ extension SessionService {
         }
 
         persistSoon()
+    }
+
+    func requestToggleBrowserSplit(for sessionID: UUID) {
+        _ = requestBrowserOpenIntent(.toggleBrowserSplit(sessionID: sessionID))
+    }
+
+    @discardableResult
+    func requestAddNiriBrowserTile(in sessionID: UUID) -> UUID? {
+        requestBrowserOpenIntent(.addNiriBrowserTile(sessionID: sessionID))
+    }
+
+    func requestOpenURLInSplit(_ url: URL, for sessionID: UUID?) {
+        guard let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https" else {
+            do {
+                try URLRoutingService(openLinksInDefaultBrowser: true).open(url)
+            } catch {
+                Logger.error("Failed to open URL in browser split: \(error.localizedDescription)")
+            }
+            return
+        }
+
+        guard let sessionID else {
+            do {
+                try URLRoutingService(openLinksInDefaultBrowser: true).open(url)
+            } catch {
+                Logger.error("Failed to open URL in default browser: \(error.localizedDescription)")
+            }
+            return
+        }
+
+        _ = requestBrowserOpenIntent(.openURLInSplit(url: url, sessionID: sessionID))
+    }
+
+    @discardableResult
+    func requestOpenClipboardURLInSplit(for sessionID: UUID?) -> Bool {
+        guard let value = NSPasteboard.general.string(forType: .string),
+              let url = normalizedURL(from: value) else {
+            return false
+        }
+        requestOpenURLInSplit(url, for: sessionID ?? selectedSessionID)
+        return true
+    }
+
+    func presentBrowserControlConsentPromptFromSettings() {
+        let mode: BrowserControlConsentPromptMode = settings.browserControlConsent == .enabled
+            ? .settingsRerun
+            : .settingsEnable
+        pendingBrowserControlConsentPrompt = BrowserControlConsentPrompt(mode: mode)
+    }
+
+    func performBrowserControlConsentPrimaryAction() {
+        guard let prompt = pendingBrowserControlConsentPrompt, !prompt.isInstalling else { return }
+        var updatedPrompt = prompt
+        updatedPrompt.isInstalling = true
+        updatedPrompt.setupErrorMessage = nil
+        pendingBrowserControlConsentPrompt = updatedPrompt
+
+        let mode = prompt.mode
+        let force = mode == .settingsRerun
+        let preferredBrowserAppURL = preferredVSCodeDebugBrowserURL()
+
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                _ = try await browserControlSetupService.provision(
+                    force: force,
+                    preferredBrowserAppURL: preferredBrowserAppURL
+                )
+
+                switch mode {
+                case .settingsRerun:
+                    if settings.browserControlConsent == .undecided {
+                        saveSettings { settings in
+                            settings.browserControlConsent = .enabled
+                        }
+                    }
+                case .firstUse, .settingsEnable:
+                    saveSettings { settings in
+                        settings.browserControlConsent = .enabled
+                    }
+                }
+
+                pendingBrowserControlConsentPrompt = nil
+                replayQueuedBrowserOpenIntents()
+            } catch {
+                switch mode {
+                case .settingsRerun:
+                    break
+                case .firstUse, .settingsEnable:
+                    saveSettings { settings in
+                        settings.browserControlConsent = .undecided
+                    }
+                }
+
+                if var prompt = pendingBrowserControlConsentPrompt {
+                    prompt.isInstalling = false
+                    prompt.setupErrorMessage = error.localizedDescription
+                    pendingBrowserControlConsentPrompt = prompt
+                } else {
+                    pendingBrowserControlConsentPrompt = BrowserControlConsentPrompt(
+                        mode: mode,
+                        isInstalling: false,
+                        setupErrorMessage: error.localizedDescription
+                    )
+                }
+                replayQueuedBrowserOpenIntents()
+            }
+        }
+    }
+
+    func performBrowserControlConsentSecondaryAction() {
+        guard let prompt = pendingBrowserControlConsentPrompt,
+              !prompt.isInstalling else { return }
+
+        switch prompt.mode {
+        case .settingsRerun:
+            pendingBrowserControlConsentPrompt = nil
+        case .firstUse, .settingsEnable:
+            saveSettings { settings in
+                settings.browserControlConsent = .declined
+            }
+            pendingBrowserControlConsentPrompt = nil
+            replayQueuedBrowserOpenIntents()
+        }
+    }
+
+    func resetBrowserControlConsentForTesting() {
+        queuedBrowserOpenIntents.removeAll()
+        pendingBrowserControlConsentPrompt = nil
+        saveSettings { settings in
+            settings.browserControlConsent = .undecided
+        }
     }
 
     func setBrowserURL(for sessionID: UUID, urlString: String?) {
@@ -510,6 +644,43 @@ extension SessionService {
         }
         openURLInSplit(url, for: sessionID ?? selectedSessionID)
         return true
+    }
+
+    @discardableResult
+    private func requestBrowserOpenIntent(_ intent: BrowserOpenIntent) -> UUID? {
+        switch settings.browserControlConsent {
+        case .enabled, .declined:
+            return replayBrowserOpenIntent(intent)
+        case .undecided:
+            queuedBrowserOpenIntents.append(intent)
+            if pendingBrowserControlConsentPrompt == nil {
+                pendingBrowserControlConsentPrompt = BrowserControlConsentPrompt(mode: .firstUse)
+            }
+            return nil
+        }
+    }
+
+    @discardableResult
+    private func replayBrowserOpenIntent(_ intent: BrowserOpenIntent) -> UUID? {
+        switch intent {
+        case .toggleBrowserSplit(let sessionID):
+            toggleBrowserSplit(for: sessionID)
+            return nil
+        case .openURLInSplit(let url, let sessionID):
+            openURLInSplit(url, for: sessionID)
+            return nil
+        case .addNiriBrowserTile(let sessionID):
+            return niriAddBrowserRight(in: sessionID)
+        }
+    }
+
+    private func replayQueuedBrowserOpenIntents() {
+        guard !queuedBrowserOpenIntents.isEmpty else { return }
+        let queued = queuedBrowserOpenIntents
+        queuedBrowserOpenIntents.removeAll()
+        for intent in queued {
+            _ = replayBrowserOpenIntent(intent)
+        }
     }
 
     func revealWorktree(for sessionID: UUID) {

--- a/idx0/Services/Session/SessionService.swift
+++ b/idx0/Services/Session/SessionService.swift
@@ -14,11 +14,13 @@ final class SessionService: ObservableObject {
     @Published var pendingWorktreeCleanupNotice: WorktreeCleanupNotice?
     @Published var pendingWorktreeDeletePrompt: WorktreeDeletePrompt?
     @Published var pendingWorktreeInspector: WorktreeInspectorRequest?
+    @Published var pendingBrowserControlConsentPrompt: BrowserControlConsentPrompt?
 
     let sessionStore: SessionStore
     let projectStore: ProjectStore
     let inboxStore: InboxStore
     let settingsStore: SettingsStore
+    let browserControlSetupService: any BrowserControlSetupServicing
     nonisolated(unsafe) let worktreeService: WorktreeServiceProtocol
     let shellHealthService = ShellIntegrationHealthService()
     let host: GhosttyAppHost
@@ -63,6 +65,7 @@ final class SessionService: ObservableObject {
     var attentionCenter = AttentionCenter()
     var notificationAuthorizationRequested = false
     var lastNotificationSentAt: [String: Date] = [:]
+    var queuedBrowserOpenIntents: [BrowserOpenIntent] = []
     let persistenceDebouncer = Debouncer(delay: 0.2)
     let persistenceQueue = DispatchQueue(label: "idx0.persistence.serial", qos: .utility)
     let restoreCoordinator = SessionRestoreCoordinator()
@@ -91,6 +94,7 @@ final class SessionService: ObservableObject {
         projectStore: ProjectStore,
         inboxStore: InboxStore,
         settingsStore: SettingsStore,
+        browserControlSetupService: (any BrowserControlSetupServicing)? = nil,
         worktreeService: WorktreeServiceProtocol,
         launcherDirectory: URL? = nil,
         ipcSocketPath: String? = nil,
@@ -102,6 +106,10 @@ final class SessionService: ObservableObject {
         self.projectStore = projectStore
         self.inboxStore = inboxStore
         self.settingsStore = settingsStore
+        self.browserControlSetupService = browserControlSetupService
+            ?? BrowserControlSetupService(
+                appSupportDirectory: settingsStore.storageURL.deletingLastPathComponent()
+            )
         self.worktreeService = worktreeService
         self.host = host
         self.launcherDirectory = launcherDirectory ?? FileManager.default.temporaryDirectory.appendingPathComponent("idx0-launchers", isDirectory: true)

--- a/idx0/UI/MainWindow/MainWindowSheets.swift
+++ b/idx0/UI/MainWindow/MainWindowSheets.swift
@@ -53,6 +53,11 @@ struct MainWindowSheets: ViewModifier {
                     .environmentObject(workflowService)
                     .frame(width: 560)
             }
+            .sheet(item: $sessionService.pendingBrowserControlConsentPrompt) { prompt in
+                BrowserControlConsentSheet(prompt: prompt)
+                    .environmentObject(sessionService)
+                    .interactiveDismissDisabled(true)
+            }
             .sheet(item: $sessionService.pendingWorktreeInspector) { request in
                 WorktreeInspectorSheet(repoPath: request.repoPath)
                     .environmentObject(sessionService)
@@ -60,4 +65,3 @@ struct MainWindowSheets: ViewModifier {
             }
     }
 }
-

--- a/idx0/UI/MainWindow/TabBarOverlay.swift
+++ b/idx0/UI/MainWindow/TabBarOverlay.swift
@@ -88,7 +88,7 @@ struct TabBarOverlay: View {
             if !sessionService.settings.niriCanvasEnabled {
                 Button {
                     if let selected = sessionService.selectedSessionID {
-                        sessionService.toggleBrowserSplit(for: selected)
+                        sessionService.requestToggleBrowserSplit(for: selected)
                     }
                 } label: {
                     Image(systemName: "rectangle.split.2x1")
@@ -144,4 +144,3 @@ struct TabBarOverlay: View {
         }
     }
 }
-

--- a/idx0/UI/Session/SessionContainer/SessionContainerView+NiriQuickAddToolbar.swift
+++ b/idx0/UI/Session/SessionContainer/SessionContainerView+NiriQuickAddToolbar.swift
@@ -137,7 +137,7 @@ extension SessionContainerView {
             searchText: "browser web view globe url http tile add",
             section: .apps,
             run: {
-                _ = self.sessionService.niriAddBrowserRight(in: sessionID)
+                _ = self.sessionService.requestAddNiriBrowserTile(in: sessionID)
             }
         ))
 

--- a/idx0/UI/Settings/Inline/InlineAdvancedSettings.swift
+++ b/idx0/UI/Settings/Inline/InlineAdvancedSettings.swift
@@ -67,6 +67,44 @@ struct InlineAdvancedSettings: View {
             }
 
             SettingDivider()
+            SettingSectionHeader(title: "Browser Control")
+
+            SettingRowView(
+                label: "Agent Browser Automation",
+                caption: browserControlStatusText
+            ) {
+                HStack(spacing: 8) {
+                    Button(primaryBrowserControlButtonTitle) {
+                        sessionService.presentBrowserControlConsentPromptFromSettings()
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(tc.secondaryText)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(tc.surface0, in: RoundedRectangle(cornerRadius: 4))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(tc.surface2.opacity(0.5), lineWidth: 0.5)
+                    )
+
+                    Button("Reset") {
+                        sessionService.resetBrowserControlConsentForTesting()
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(tc.tertiaryText)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(tc.surface0, in: RoundedRectangle(cornerRadius: 4))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(tc.surface2.opacity(0.5), lineWidth: 0.5)
+                    )
+                }
+            }
+
+            SettingDivider()
             SettingSectionHeader(title: "Reset")
 
             VStack(alignment: .leading, spacing: 10) {
@@ -156,5 +194,22 @@ struct InlineAdvancedSettings: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
         .background(tc.surface0, in: RoundedRectangle(cornerRadius: 4))
+    }
+
+    private var primaryBrowserControlButtonTitle: String {
+        sessionService.settings.browserControlConsent == .enabled
+            ? "Re-run Browser Control Setup"
+            : "Enable Browser Control"
+    }
+
+    private var browserControlStatusText: String {
+        switch sessionService.settings.browserControlConsent {
+        case .undecided:
+            return "Browser control has not been configured yet."
+        case .enabled:
+            return "Browser control is enabled."
+        case .declined:
+            return "Browser control prompt was declined. You can enable it any time."
+        }
     }
 }

--- a/idx0/UI/Settings/Tabs/AdvancedSettingsTab.swift
+++ b/idx0/UI/Settings/Tabs/AdvancedSettingsTab.swift
@@ -25,6 +25,26 @@ struct AdvancedSettingsTab: View {
                     .foregroundStyle(.tertiary)
             }
 
+            Section("Browser Control") {
+                if sessionService.settings.browserControlConsent == .enabled {
+                    Button("Re-run Browser Control Setup") {
+                        sessionService.presentBrowserControlConsentPromptFromSettings()
+                    }
+                } else {
+                    Button("Enable Browser Control") {
+                        sessionService.presentBrowserControlConsentPromptFromSettings()
+                    }
+                }
+
+                Button("Reset Browser Control Consent (for testing)") {
+                    sessionService.resetBrowserControlConsentForTesting()
+                }
+
+                Text(browserControlStatusText)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
             Section("Reset") {
                 Button("Reset Niri Walkthrough (requires restart)") {
                     sessionService.saveSettings { settings in
@@ -53,5 +73,16 @@ struct AdvancedSettingsTab: View {
         }
         .formStyle(.grouped)
         .padding(10)
+    }
+
+    private var browserControlStatusText: String {
+        switch sessionService.settings.browserControlConsent {
+        case .undecided:
+            return "Browser control has not been configured yet."
+        case .enabled:
+            return "Browser control is enabled."
+        case .declined:
+            return "Browser control prompt was declined. You can enable it any time."
+        }
     }
 }

--- a/idx0/UI/Sheets/BrowserControlConsentSheet.swift
+++ b/idx0/UI/Sheets/BrowserControlConsentSheet.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct BrowserControlConsentSheet: View {
+    @EnvironmentObject private var sessionService: SessionService
+
+    let prompt: BrowserControlConsentPrompt
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(titleText)
+                .font(.title3.weight(.semibold))
+
+            Text(bodyText)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let errorText = prompt.setupErrorMessage, !errorText.isEmpty {
+                Text(errorText)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.red.opacity(0.08), in: RoundedRectangle(cornerRadius: 8))
+            }
+
+            if prompt.isInstalling {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Configuring browser control...")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button(secondaryActionTitle) {
+                    sessionService.performBrowserControlConsentSecondaryAction()
+                }
+                .disabled(prompt.isInstalling)
+
+                Button(primaryActionTitle) {
+                    sessionService.performBrowserControlConsentPrimaryAction()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(prompt.isInstalling)
+            }
+        }
+        .padding(20)
+        .frame(width: 520)
+    }
+
+    private var titleText: String {
+        switch prompt.mode {
+        case .firstUse, .settingsEnable:
+            return "Enable Browser Control?"
+        case .settingsRerun:
+            return "Re-run Browser Control Setup?"
+        }
+    }
+
+    private var bodyText: String {
+        switch prompt.mode {
+        case .firstUse, .settingsEnable:
+            return "This enables agent tools to drive browser automation from IDX0 by installing and configuring the local MCP browser-control server."
+        case .settingsRerun:
+            return "This will reinstall and reconfigure browser control for supported installed CLIs."
+        }
+    }
+
+    private var primaryActionTitle: String {
+        switch prompt.mode {
+        case .firstUse, .settingsEnable:
+            return "Enable Browser Control"
+        case .settingsRerun:
+            return "Re-run Browser Control Setup"
+        }
+    }
+
+    private var secondaryActionTitle: String {
+        switch prompt.mode {
+        case .firstUse, .settingsEnable:
+            return "Not now"
+        case .settingsRerun:
+            return "Close"
+        }
+    }
+}

--- a/idx0Tests/AppSettingsKeyboardTests.swift
+++ b/idx0Tests/AppSettingsKeyboardTests.swift
@@ -20,6 +20,7 @@ final class AppSettingsKeyboardTests: XCTestCase {
         XCTAssertNil(decoded.terminalStartupCommandTemplate)
         XCTAssertNil(decoded.niri.defaultNewColumnWidth)
         XCTAssertNil(decoded.niri.defaultNewTileHeight)
+        XCTAssertEqual(decoded.browserControlConsent, .undecided)
     }
 
     func testRoundTripPersistsKeyboardSettings() throws {
@@ -31,6 +32,7 @@ final class AppSettingsKeyboardTests: XCTestCase {
         settings.terminalStartupCommandTemplate = "cd ${WORKDIR} && echo ${SESSION_ID}"
         settings.niri.defaultNewColumnWidth = 920
         settings.niri.defaultNewTileHeight = 540
+        settings.browserControlConsent = .enabled
         settings.customKeybindings[ShortcutActionID.niriToggleOverview.rawValue] = KeyChord(
             key: .o,
             modifiers: [.option, .control]
@@ -46,6 +48,7 @@ final class AppSettingsKeyboardTests: XCTestCase {
         XCTAssertEqual(decoded.terminalStartupCommandTemplate, "cd ${WORKDIR} && echo ${SESSION_ID}")
         XCTAssertEqual(decoded.niri.defaultNewColumnWidth, 920)
         XCTAssertEqual(decoded.niri.defaultNewTileHeight, 540)
+        XCTAssertEqual(decoded.browserControlConsent, .enabled)
         XCTAssertEqual(
             decoded.customKeybindings[ShortcutActionID.niriToggleOverview.rawValue],
             KeyChord(key: .o, modifiers: [.option, .control])

--- a/idx0Tests/Apps/OpenCode/OpenCodeRuntimeTests.swift
+++ b/idx0Tests/Apps/OpenCode/OpenCodeRuntimeTests.swift
@@ -48,6 +48,79 @@ final class OpenCodeRuntimeTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: paths.sessionDirectory.path))
     }
 
+    func testPrepareSessionStateMergesBrowserControlMCPConfigWithoutClobberingExistingConfig() throws {
+        let root = temporaryOpenCodeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let idx0Root = root.appendingPathComponent("idx0", isDirectory: true)
+        let openCodeRoot = idx0Root.appendingPathComponent("opencode", isDirectory: true)
+        try FileManager.default.createDirectory(at: openCodeRoot, withIntermediateDirectories: true)
+
+        let wrapperScriptURL = BrowserControlSetupService.wrapperScriptURL(appSupportDirectory: idx0Root)
+        try FileManager.default.createDirectory(at: wrapperScriptURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "#!/bin/sh\nexit 0\n".write(to: wrapperScriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: wrapperScriptURL.path)
+
+        let sessionID = UUID()
+        let paths = OpenCodeRuntimePaths(sessionID: sessionID, rootDirectoryOverride: openCodeRoot)
+        let manager = OpenCodeStateSnapshotManager()
+
+        let configDirectoryURL = paths.xdgConfigHomeDirectory.appendingPathComponent("opencode", isDirectory: true)
+        try FileManager.default.createDirectory(at: configDirectoryURL, withIntermediateDirectories: true)
+        let configURL = configDirectoryURL.appendingPathComponent("opencode.json", isDirectory: false)
+        let existingConfig = """
+        {
+          "$schema": "https://opencode.ai/config.json",
+          "mcp": {
+            "existing-server": {
+              "type": "remote",
+              "url": "https://example.com/mcp"
+            }
+          },
+          "tools": {
+            "existing-server_*": false
+          }
+        }
+        """
+        try existingConfig.write(to: configURL, atomically: true, encoding: .utf8)
+
+        _ = try manager.prepareSessionState(paths: paths)
+
+        let updatedData = try Data(contentsOf: configURL)
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: updatedData) as? [String: Any]
+        )
+        let mcp = try XCTUnwrap(json["mcp"] as? [String: Any])
+        XCTAssertNotNil(mcp["existing-server"])
+        let idx0Browser = try XCTUnwrap(mcp[BrowserControlSetupService.mcpServerName] as? [String: Any])
+        XCTAssertEqual(idx0Browser["type"] as? String, "local")
+        XCTAssertEqual(idx0Browser["enabled"] as? Bool, true)
+        XCTAssertEqual(idx0Browser["command"] as? [String], [wrapperScriptURL.path])
+
+        let tools = try XCTUnwrap(json["tools"] as? [String: Any])
+        XCTAssertEqual(tools["existing-server_*"] as? Bool, false)
+    }
+
+    func testPrepareSessionStateSkipsBrowserControlConfigWhenWrapperIsUnavailable() throws {
+        let root = temporaryOpenCodeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let idx0Root = root.appendingPathComponent("idx0", isDirectory: true)
+        let openCodeRoot = idx0Root.appendingPathComponent("opencode", isDirectory: true)
+        try FileManager.default.createDirectory(at: openCodeRoot, withIntermediateDirectories: true)
+
+        let sessionID = UUID()
+        let paths = OpenCodeRuntimePaths(sessionID: sessionID, rootDirectoryOverride: openCodeRoot)
+        let manager = OpenCodeStateSnapshotManager()
+
+        _ = try manager.prepareSessionState(paths: paths)
+
+        let configURL = paths.xdgConfigHomeDirectory
+            .appendingPathComponent("opencode", isDirectory: true)
+            .appendingPathComponent("opencode.json", isDirectory: false)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: configURL.path))
+    }
+
     func testOpenCodeRuntimeStateDisplayMessagesAreStable() {
         XCTAssertEqual(OpenCodeTileRuntimeState.idle.displayMessage, "Ready")
         XCTAssertEqual(OpenCodeTileRuntimeState.starting.displayMessage, "Starting OpenCode...")

--- a/idx0Tests/BrowserControlSetupServiceTests.swift
+++ b/idx0Tests/BrowserControlSetupServiceTests.swift
@@ -1,0 +1,190 @@
+import Foundation
+import XCTest
+@testable import idx0
+
+final class BrowserControlSetupServiceTests: XCTestCase {
+    func testProvisionInstallsWrapperAndConfiguresSupportedInstalledCLIs() async throws {
+        let appSupport = temporaryAppSupportRoot()
+        defer { try? FileManager.default.removeItem(at: appSupport) }
+
+        let runner = RecordingProcessRunner { executable, arguments, _ in
+            if executable == "/usr/bin/env", arguments.first == "npm" {
+                if let prefixIndex = arguments.firstIndex(of: "--prefix"),
+                   arguments.indices.contains(prefixIndex + 1) {
+                    let installRoot = URL(fileURLWithPath: arguments[prefixIndex + 1], isDirectory: true)
+                    let binaryURL = installRoot
+                        .appendingPathComponent("node_modules", isDirectory: true)
+                        .appendingPathComponent(".bin", isDirectory: true)
+                        .appendingPathComponent("playwright-mcp", isDirectory: false)
+                    try FileManager.default.createDirectory(at: binaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+                    try "#!/bin/sh\nexit 0\n".write(to: binaryURL, atomically: true, encoding: .utf8)
+                    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryURL.path)
+                }
+                return ProcessResult(exitCode: 0, stdout: "", stderr: "")
+            }
+            return ProcessResult(exitCode: 0, stdout: "", stderr: "")
+        }
+
+        let discoveredTools = [
+            VibeCLITool(id: "codex", displayName: "Codex", executableName: "codex", launchCommand: "codex", isInstalled: true, resolvedPath: "/usr/local/bin/codex"),
+            VibeCLITool(id: "claude", displayName: "Claude", executableName: "claude", launchCommand: "claude", isInstalled: true, resolvedPath: "/usr/local/bin/claude"),
+            VibeCLITool(id: "gemini-cli", displayName: "Gemini", executableName: "gemini", launchCommand: "gemini", isInstalled: true, resolvedPath: "/usr/local/bin/gemini"),
+        ]
+
+        let service = BrowserControlSetupService(
+            appSupportDirectory: appSupport,
+            processRunner: runner,
+            discoveredToolsProvider: { discoveredTools }
+        )
+
+        let result = try await service.provision(force: false, preferredBrowserAppURL: nil)
+
+        XCTAssertEqual(result.serverName, BrowserControlSetupService.mcpServerName)
+        XCTAssertEqual(result.configuredToolIDs, ["claude", "codex", "gemini-cli"])
+        XCTAssertTrue(result.skippedToolIDs.isEmpty)
+        XCTAssertEqual(result.wrapperCommand, [result.wrapperScriptPath])
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: result.wrapperScriptPath))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.chromiumProfilePath))
+
+        let commands = await runner.recordedInvocations()
+        XCTAssertTrue(commands.contains {
+            $0.executable == "/usr/local/bin/codex" &&
+                $0.arguments == ["mcp", "add", "idx0-browser", "--", result.wrapperScriptPath]
+        })
+        XCTAssertTrue(commands.contains {
+            $0.executable == "/usr/local/bin/claude" &&
+                $0.arguments == ["mcp", "add", "--scope", "user", "idx0-browser", "--", result.wrapperScriptPath]
+        })
+        XCTAssertTrue(commands.contains {
+            $0.executable == "/usr/local/bin/gemini" &&
+                $0.arguments == ["mcp", "add", "--scope", "user", "idx0-browser", result.wrapperScriptPath]
+        })
+    }
+
+    func testProvisionIsIdempotentWhenManifestAndArtifactsExist() async throws {
+        let appSupport = temporaryAppSupportRoot()
+        defer { try? FileManager.default.removeItem(at: appSupport) }
+
+        let runner = RecordingProcessRunner { executable, arguments, _ in
+            if executable == "/usr/bin/env", arguments.first == "npm" {
+                if let prefixIndex = arguments.firstIndex(of: "--prefix"),
+                   arguments.indices.contains(prefixIndex + 1) {
+                    let installRoot = URL(fileURLWithPath: arguments[prefixIndex + 1], isDirectory: true)
+                    let binaryURL = installRoot
+                        .appendingPathComponent("node_modules", isDirectory: true)
+                        .appendingPathComponent(".bin", isDirectory: true)
+                        .appendingPathComponent("playwright-mcp", isDirectory: false)
+                    try FileManager.default.createDirectory(at: binaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+                    try "#!/bin/sh\nexit 0\n".write(to: binaryURL, atomically: true, encoding: .utf8)
+                    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryURL.path)
+                }
+                return ProcessResult(exitCode: 0, stdout: "", stderr: "")
+            }
+            return ProcessResult(exitCode: 0, stdout: "", stderr: "")
+        }
+
+        let discoveredTools = [
+            VibeCLITool(id: "codex", displayName: "Codex", executableName: "codex", launchCommand: "codex", isInstalled: true, resolvedPath: "/usr/local/bin/codex"),
+        ]
+
+        let service = BrowserControlSetupService(
+            appSupportDirectory: appSupport,
+            processRunner: runner,
+            discoveredToolsProvider: { discoveredTools }
+        )
+
+        _ = try await service.provision(force: false, preferredBrowserAppURL: nil)
+        let firstCommandCount = await runner.recordedInvocations().count
+        XCTAssertGreaterThan(firstCommandCount, 0)
+
+        _ = try await service.provision(force: false, preferredBrowserAppURL: nil)
+        let secondCommandCount = await runner.recordedInvocations().count
+
+        XCTAssertEqual(secondCommandCount, firstCommandCount)
+    }
+
+    func testProvisionFailsWhenInstalledCLIConfigFails() async throws {
+        let appSupport = temporaryAppSupportRoot()
+        defer { try? FileManager.default.removeItem(at: appSupport) }
+
+        let runner = RecordingProcessRunner { executable, arguments, _ in
+            if executable == "/usr/bin/env", arguments.first == "npm" {
+                if let prefixIndex = arguments.firstIndex(of: "--prefix"),
+                   arguments.indices.contains(prefixIndex + 1) {
+                    let installRoot = URL(fileURLWithPath: arguments[prefixIndex + 1], isDirectory: true)
+                    let binaryURL = installRoot
+                        .appendingPathComponent("node_modules", isDirectory: true)
+                        .appendingPathComponent(".bin", isDirectory: true)
+                        .appendingPathComponent("playwright-mcp", isDirectory: false)
+                    try FileManager.default.createDirectory(at: binaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+                    try "#!/bin/sh\nexit 0\n".write(to: binaryURL, atomically: true, encoding: .utf8)
+                    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryURL.path)
+                }
+                return ProcessResult(exitCode: 0, stdout: "", stderr: "")
+            }
+            if executable == "/usr/local/bin/codex",
+               arguments.prefix(3).elementsEqual(["mcp", "add", "idx0-browser"]) {
+                return ProcessResult(exitCode: 1, stdout: "", stderr: "failed to write config")
+            }
+            return ProcessResult(exitCode: 0, stdout: "", stderr: "")
+        }
+
+        let discoveredTools = [
+            VibeCLITool(id: "codex", displayName: "Codex", executableName: "codex", launchCommand: "codex", isInstalled: true, resolvedPath: "/usr/local/bin/codex"),
+        ]
+
+        let service = BrowserControlSetupService(
+            appSupportDirectory: appSupport,
+            processRunner: runner,
+            discoveredToolsProvider: { discoveredTools }
+        )
+
+        do {
+            _ = try await service.provision(force: false, preferredBrowserAppURL: nil)
+            XCTFail("Expected CLI configuration failure")
+        } catch let error as BrowserControlSetupError {
+            guard case .cliConfigurationFailed(let toolID, _, _) = error else {
+                XCTFail("Unexpected setup error: \(error)")
+                return
+            }
+            XCTAssertEqual(toolID, "codex")
+        }
+    }
+
+    private func temporaryAppSupportRoot() -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("idx0-browser-control-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+}
+
+private actor RecordingProcessRunner: ProcessRunnerProtocol {
+    struct Invocation: Equatable {
+        let executable: String
+        let arguments: [String]
+        let currentDirectory: String?
+    }
+
+    private let handler: @Sendable (String, [String], String?) async throws -> ProcessResult
+    private var invocations: [Invocation] = []
+
+    init(handler: @escaping @Sendable (String, [String], String?) async throws -> ProcessResult) {
+        self.handler = handler
+    }
+
+    func run(executable: String, arguments: [String], currentDirectory: String?) async throws -> ProcessResult {
+        invocations.append(
+            Invocation(
+                executable: executable,
+                arguments: arguments,
+                currentDirectory: currentDirectory
+            )
+        )
+        return try await handler(executable, arguments, currentDirectory)
+    }
+
+    func recordedInvocations() -> [Invocation] {
+        invocations
+    }
+}

--- a/idx0Tests/SessionServiceTests+BrowserControl.swift
+++ b/idx0Tests/SessionServiceTests+BrowserControl.swift
@@ -1,0 +1,170 @@
+import AppKit
+import XCTest
+@testable import idx0
+
+extension SessionServiceTests {
+    func testBrowserConsentPromptAppearsAndQueuesOnFirstBrowserOpen() async throws {
+        let fixture = try Fixture()
+        let service = fixture.service
+        service.saveSettings { settings in
+            settings.browserControlConsent = .undecided
+            settings.niriCanvasEnabled = false
+        }
+
+        let session = try await service.createSession(from: SessionCreationRequest(title: "Browser Consent Queue")).session
+        service.requestToggleBrowserSplit(for: session.id)
+
+        XCTAssertEqual(service.queuedBrowserOpenIntents.count, 1)
+        XCTAssertNotNil(service.pendingBrowserControlConsentPrompt)
+        XCTAssertFalse(service.sessions.first(where: { $0.id == session.id })?.browserState?.isVisible ?? false)
+    }
+
+    func testBrowserConsentDeclineReplaysQueuedIntentAndSuppressesFuturePrompt() async throws {
+        let fixture = try Fixture()
+        let service = fixture.service
+        service.saveSettings { settings in
+            settings.browserControlConsent = .undecided
+            settings.niriCanvasEnabled = false
+        }
+
+        let session = try await service.createSession(from: SessionCreationRequest(title: "Browser Consent Decline")).session
+        service.requestToggleBrowserSplit(for: session.id)
+        service.performBrowserControlConsentSecondaryAction()
+
+        XCTAssertEqual(service.settings.browserControlConsent, .declined)
+        XCTAssertTrue(service.sessions.first(where: { $0.id == session.id })?.browserState?.isVisible ?? false)
+        XCTAssertNil(service.pendingBrowserControlConsentPrompt)
+        XCTAssertTrue(service.queuedBrowserOpenIntents.isEmpty)
+
+        service.requestToggleBrowserSplit(for: session.id)
+        XCTAssertNil(service.pendingBrowserControlConsentPrompt)
+        XCTAssertFalse(service.sessions.first(where: { $0.id == session.id })?.browserState?.isVisible ?? true)
+    }
+
+    func testBrowserConsentEnableSuccessStoresEnabledAndReplaysQueuedIntent() async throws {
+        let setupService = StubBrowserControlSetupService(results: [.success])
+        let fixture = try Fixture(browserControlSetupService: setupService)
+        let service = fixture.service
+        service.saveSettings { settings in
+            settings.browserControlConsent = .undecided
+            settings.niriCanvasEnabled = false
+        }
+
+        let session = try await service.createSession(from: SessionCreationRequest(title: "Browser Consent Enable")).session
+        service.requestToggleBrowserSplit(for: session.id)
+        service.performBrowserControlConsentPrimaryAction()
+
+        await waitForCondition {
+            service.pendingBrowserControlConsentPrompt == nil &&
+                service.settings.browserControlConsent == .enabled &&
+                (service.sessions.first(where: { $0.id == session.id })?.browserState?.isVisible ?? false)
+        }
+
+        let invocations = await setupService.recordedInvocations()
+        XCTAssertEqual(invocations.count, 1)
+        XCTAssertEqual(invocations.first?.force, false)
+    }
+
+    func testBrowserConsentEnableFailureKeepsUndecidedShowsErrorAndStillReplaysIntent() async throws {
+        let setupService = StubBrowserControlSetupService(results: [.failure("setup failed")])
+        let fixture = try Fixture(browserControlSetupService: setupService)
+        let service = fixture.service
+        service.saveSettings { settings in
+            settings.browserControlConsent = .undecided
+            settings.niriCanvasEnabled = false
+        }
+
+        let session = try await service.createSession(from: SessionCreationRequest(title: "Browser Consent Failure")).session
+        service.requestToggleBrowserSplit(for: session.id)
+        service.performBrowserControlConsentPrimaryAction()
+
+        await waitForCondition {
+            service.pendingBrowserControlConsentPrompt?.isInstalling == false &&
+                service.pendingBrowserControlConsentPrompt?.setupErrorMessage != nil
+        }
+
+        XCTAssertEqual(service.settings.browserControlConsent, .undecided)
+        XCTAssertTrue(service.sessions.first(where: { $0.id == session.id })?.browserState?.isVisible ?? false)
+        XCTAssertTrue(service.queuedBrowserOpenIntents.isEmpty)
+    }
+
+    func testBrowserConsentGateCoversNiriBrowserTileAndClipboardOpen() async throws {
+        let fixture = try Fixture()
+        let service = fixture.service
+        service.saveSettings { settings in
+            settings.browserControlConsent = .undecided
+            settings.niriCanvasEnabled = true
+        }
+
+        let session = try await service.createSession(from: SessionCreationRequest(title: "Browser Action Coverage")).session
+        service.ensureNiriLayoutState(for: session.id)
+
+        let niriResult = service.requestAddNiriBrowserTile(in: session.id)
+        XCTAssertNil(niriResult)
+        XCTAssertEqual(service.queuedBrowserOpenIntents.count, 1)
+        XCTAssertNotNil(service.pendingBrowserControlConsentPrompt)
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("https://example.com", forType: .string)
+        let openedClipboard = service.requestOpenClipboardURLInSplit(for: session.id)
+        XCTAssertTrue(openedClipboard)
+        XCTAssertEqual(service.queuedBrowserOpenIntents.count, 2)
+    }
+
+    private func waitForCondition(
+        timeout: TimeInterval = 2.0,
+        condition: @escaping () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        XCTFail("Timed out waiting for condition")
+    }
+}
+
+private actor StubBrowserControlSetupService: BrowserControlSetupServicing {
+    enum Result {
+        case success
+        case failure(String)
+    }
+
+    struct Invocation: Equatable {
+        let force: Bool
+    }
+
+    private var results: [Result]
+    private var invocations: [Invocation] = []
+
+    init(results: [Result]) {
+        self.results = results
+    }
+
+    func provision(force: Bool, preferredBrowserAppURL: URL?) async throws -> BrowserControlSetupResult {
+        invocations.append(Invocation(force: force))
+        let next = results.isEmpty ? .success : results.removeFirst()
+        switch next {
+        case .success:
+            return BrowserControlSetupResult(
+                serverName: BrowserControlSetupService.mcpServerName,
+                wrapperCommand: ["/tmp/idx0-browser-wrapper"],
+                wrapperScriptPath: "/tmp/idx0-browser-wrapper",
+                chromiumProfilePath: "/tmp/idx0-browser-profile",
+                browserExecutablePath: nil,
+                configuredToolIDs: [],
+                skippedToolIDs: []
+            )
+        case .failure(let message):
+            throw NSError(domain: "BrowserControlSetupTests", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: message
+            ])
+        }
+    }
+
+    func recordedInvocations() -> [Invocation] {
+        invocations
+    }
+}

--- a/idx0Tests/SessionServiceTests.swift
+++ b/idx0Tests/SessionServiceTests.swift
@@ -658,7 +658,8 @@ final class SessionServiceTests: XCTestCase {
 
     static func makeService(
         root: URL,
-        niriAppRegistry: NiriAppRegistry = NiriAppRegistry()
+        niriAppRegistry: NiriAppRegistry = NiriAppRegistry(),
+        browserControlSetupService: (any BrowserControlSetupServicing)? = nil
     ) throws -> SessionService {
         let paths = FileSystemPaths(
             appSupportDirectory: root,
@@ -679,6 +680,7 @@ final class SessionServiceTests: XCTestCase {
             projectStore: ProjectStore(url: paths.projectsFile),
             inboxStore: InboxStore(url: paths.inboxFile),
             settingsStore: SettingsStore(url: paths.settingsFile),
+            browserControlSetupService: browserControlSetupService,
             worktreeService: worktree,
             launcherDirectory: root.appendingPathComponent("launchers", isDirectory: true),
             niriAppRegistry: niriAppRegistry,
@@ -690,12 +692,19 @@ final class SessionServiceTests: XCTestCase {
     struct Fixture {
         let service: SessionService
 
-        init(niriAppRegistry: NiriAppRegistry = NiriAppRegistry()) throws {
+        init(
+            niriAppRegistry: NiriAppRegistry = NiriAppRegistry(),
+            browserControlSetupService: (any BrowserControlSetupServicing)? = nil
+        ) throws {
             let root = FileManager.default.temporaryDirectory
                 .appendingPathComponent("idx0-service-tests-\(UUID().uuidString)", isDirectory: true)
             try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
 
-            service = try SessionServiceTests.makeService(root: root, niriAppRegistry: niriAppRegistry)
+            service = try SessionServiceTests.makeService(
+                root: root,
+                niriAppRegistry: niriAppRegistry,
+                browserControlSetupService: browserControlSetupService
+            )
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a first-use browser-control consent flow and app-managed setup pipeline so browser surfaces can be opened immediately while enabling MCP-based browser automation for supported installed CLIs.

## Details

- Added `BrowserControlConsent` state to app settings (`undecided` / `enabled` / `declined`) with schema migration defaults.
- Added consent-aware browser entrypoints in `SessionService`:
  - `requestToggleBrowserSplit(...)`
  - `requestOpenURLInSplit(...)`
  - `requestAddNiriBrowserTile(...)`
- Added queued browser-intent replay logic:
  - First browser open while undecided shows a modal and queues intent.
  - `Not now` stores `declined` and replays queued action(s).
  - `Enable Browser Control` runs setup; on success stores `enabled` and replays queued action(s).
  - Setup failure keeps consent unresolved, shows retry/error state, and still replays queued action(s).
- Added `BrowserControlConsentSheet` to main window sheet stack.
- Added Advanced settings controls:
  - Enable browser control (when declined/undecided)
  - Re-run setup (when enabled)
  - Reset consent to undecided (testing support)
- Added `BrowserControlSetupService` actor:
  - Installs pinned `@playwright/mcp@0.0.68` under app support (`.../idx0/browser-control/`)
  - Generates executable wrapper script using a dedicated Chromium profile dir
  - Configures installed CLIs in one pass (`codex`, `claude`, `gemini`) using each CLI’s MCP commands
  - Skips non-installed tools, fails with actionable errors for installed-tool config failures
  - Uses a manifest marker for idempotent repeated runs
- Added OpenCode runtime MCP merge:
  - Writes/merges `idx0-browser` local MCP entry into isolated `xdg-config/opencode/opencode.json` without clobbering existing config.
- Added T3 runtime troubleshooting note in runtime logs when browser control is enabled.
- Added/updated tests for settings migration, consent gating behavior, setup service idempotency/failure, and OpenCode config merge.

## Related Issues

N/A

## How to Validate

1. Run targeted coverage for this change:
   - `xcodebuild -project idx0.xcodeproj -scheme idx0 -destination 'platform=macOS' test -only-testing:idx0Tests/AppSettingsKeyboardTests -only-testing:idx0Tests/OpenCodeRuntimeTests -only-testing:idx0Tests/BrowserControlSetupServiceTests -only-testing:idx0Tests/SessionServiceTests/testBrowserConsentPromptAppearsAndQueuesOnFirstBrowserOpen -only-testing:idx0Tests/SessionServiceTests/testBrowserConsentDeclineReplaysQueuedIntentAndSuppressesFuturePrompt -only-testing:idx0Tests/SessionServiceTests/testBrowserConsentEnableSuccessStoresEnabledAndReplaysQueuedIntent -only-testing:idx0Tests/SessionServiceTests/testBrowserConsentEnableFailureKeepsUndecidedShowsErrorAndStillReplaysIntent -only-testing:idx0Tests/SessionServiceTests/testBrowserConsentGateCoversNiriBrowserTileAndClipboardOpen`
2. Run full suite:
   - `xcodebuild -project idx0.xcodeproj -scheme idx0 -destination 'platform=macOS' test`
3. Expected full-suite status:
   - Existing known failures remain in Niri sizing persistence tests:
     - `SessionServiceTests/testNiriColumnResizePersistsPreferredWidths()`
     - `SessionServiceTests/testNiriDefaultTileSizesApplyOnlyToNewTiles()`
     - `SessionServiceTests/testNiriItemResizePersistsPreferredHeights()`
4. Manual smoke test:
   - Launch app, trigger browser split or Niri browser tile on first use, confirm consent sheet appears.
   - Verify `Not now` still opens requested browser surface and suppresses future prompts.
   - Use Settings -> Advanced to enable/re-run browser control and verify flow completes.

## Pre-Merge Checklist

- [x] Builds successfully (`xcodebuild` / Xcode)
- [x] Added/updated tests (if needed)
- [x] Updated relevant documentation and README (if needed)
- [x] Noted breaking changes (if any)
- [x] Tested on macOS
