### PR TITLE
feat(worktree): repo-local random worktrees and default repo session worktrees

### DIFF
--- a/idx0/Services/Git/WorktreeService.swift
+++ b/idx0/Services/Git/WorktreeService.swift
@@ -38,10 +38,21 @@ protocol WorktreeServiceProtocol {
 struct WorktreeService: WorktreeServiceProtocol {
     private let gitService: GitServiceProtocol
     private let paths: FileSystemPaths
+    private let fileManager: FileManager
+    private let worktreeNameGenerator: () -> String
 
-    init(gitService: GitServiceProtocol, paths: FileSystemPaths) {
+    init(
+        gitService: GitServiceProtocol,
+        paths: FileSystemPaths,
+        fileManager: FileManager = .default,
+        worktreeNameGenerator: @escaping () -> String = {
+            String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(12)).lowercased()
+        }
+    ) {
         self.gitService = gitService
         self.paths = paths
+        self.fileManager = fileManager
+        self.worktreeNameGenerator = worktreeNameGenerator
     }
 
     func validateRepo(path: String) async throws -> GitRepoInfo {
@@ -94,7 +105,14 @@ struct WorktreeService: WorktreeServiceProtocol {
             throw WorktreeServiceError.invalidBranchName
         }
 
-        let worktreePath = uniqueWorktreePath(repoName: info.repoName, branchName: resolvedBranch)
+        ensureIDX0ExcludedInLocalRepo(repoTopLevelPath: info.topLevelPath)
+
+        let worktreePath: String
+        do {
+            worktreePath = try uniqueWorktreePath(repoTopLevelPath: info.topLevelPath)
+        } catch {
+            throw WorktreeServiceError.createFailed("Unable to prepare workspace worktree directory: \(error.localizedDescription)")
+        }
 
         do {
             return try await gitService.createWorktree(
@@ -145,22 +163,109 @@ struct WorktreeService: WorktreeServiceProtocol {
         }
     }
 
-    private func uniqueWorktreePath(repoName: String, branchName: String) -> String {
-        let safeRepo = BranchNameGenerator.slugify(repoName)
-        let safeBranch = BranchNameGenerator.slugify(branchName)
-        let root = paths.worktreesDirectory
-            .appendingPathComponent(safeRepo, isDirectory: true)
-
-        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-
-        var candidate = root.appendingPathComponent(safeBranch, isDirectory: true)
+    private func uniqueWorktreePath(repoTopLevelPath: String) throws -> String {
+        let root = try workspaceWorktreesDirectoryURL(repoTopLevelPath: repoTopLevelPath)
+        let baseName = "wt-\(sanitizedWorktreeToken(worktreeNameGenerator()))"
+        var candidate = root.appendingPathComponent(baseName, isDirectory: true)
         var suffix = 2
 
-        while FileManager.default.fileExists(atPath: candidate.path) {
-            candidate = root.appendingPathComponent("\(safeBranch)-\(suffix)", isDirectory: true)
+        while fileManager.fileExists(atPath: candidate.path) {
+            candidate = root.appendingPathComponent("\(baseName)-\(suffix)", isDirectory: true)
             suffix += 1
         }
 
         return candidate.path
+    }
+
+    private func workspaceWorktreesDirectoryURL(repoTopLevelPath: String) throws -> URL {
+        let root = URL(fileURLWithPath: repoTopLevelPath)
+            .standardizedFileURL
+            .appendingPathComponent(".idx0", isDirectory: true)
+            .appendingPathComponent("worktrees", isDirectory: true)
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private func sanitizedWorktreeToken(_ rawValue: String) -> String {
+        let token = rawValue.lowercased().filter { character in
+            ("a"..."z").contains(character) || ("0"..."9").contains(character)
+        }
+        if !token.isEmpty {
+            return String(token.prefix(12))
+        }
+        return String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(12)).lowercased()
+    }
+
+    private func ensureIDX0ExcludedInLocalRepo(repoTopLevelPath: String) {
+        guard let excludeFileURL = localGitExcludeURL(repoTopLevelPath: repoTopLevelPath) else {
+            return
+        }
+
+        do {
+            try fileManager.createDirectory(
+                at: excludeFileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+
+            let existing = (try? String(contentsOf: excludeFileURL, encoding: .utf8)) ?? ""
+            let entries = existing
+                .components(separatedBy: .newlines)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            guard !entries.contains(".idx0/") else { return }
+
+            var updated = existing
+            if !updated.isEmpty, !updated.hasSuffix("\n") {
+                updated.append("\n")
+            }
+            updated.append(".idx0/\n")
+            try updated.write(to: excludeFileURL, atomically: true, encoding: .utf8)
+        } catch {
+            Logger.error("Failed to update local git exclude for .idx0/: \(error.localizedDescription)")
+        }
+    }
+
+    private func localGitExcludeURL(repoTopLevelPath: String) -> URL? {
+        guard let gitDirectory = gitDirectoryURL(repoTopLevelPath: repoTopLevelPath) else {
+            return nil
+        }
+        return gitDirectory
+            .appendingPathComponent("info", isDirectory: true)
+            .appendingPathComponent("exclude", isDirectory: false)
+    }
+
+    private func gitDirectoryURL(repoTopLevelPath: String) -> URL? {
+        let repoURL = URL(fileURLWithPath: repoTopLevelPath).standardizedFileURL
+        let dotGitURL = repoURL.appendingPathComponent(".git", isDirectory: false)
+
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: dotGitURL.path, isDirectory: &isDirectory) else {
+            return nil
+        }
+
+        if isDirectory.boolValue {
+            return dotGitURL
+        }
+
+        guard let dotGitContents = try? String(contentsOf: dotGitURL, encoding: .utf8),
+              let directiveLine = dotGitContents
+                .components(separatedBy: .newlines)
+                .first(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+        else {
+            return nil
+        }
+
+        let trimmed = directiveLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.lowercased().hasPrefix("gitdir:") else { return nil }
+
+        let rawPath = String(trimmed.dropFirst("gitdir:".count)).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawPath.isEmpty else { return nil }
+
+        let resolved: URL
+        if rawPath.hasPrefix("/") {
+            resolved = URL(fileURLWithPath: rawPath, isDirectory: true)
+        } else {
+            resolved = repoURL.appendingPathComponent(rawPath, isDirectory: true)
+        }
+        return resolved.standardizedFileURL
     }
 }

--- a/idx0/Services/Git/WorktreeService.swift
+++ b/idx0/Services/Git/WorktreeService.swift
@@ -1,271 +1,271 @@
 import Foundation
 
 enum WorktreeServiceError: LocalizedError {
-    case invalidFolder
-    case invalidBranchName
-    case invalidWorktreePath
-    case worktreeNotFound
-    case worktreeDirty
-    case createFailed(String)
+  case invalidFolder
+  case invalidBranchName
+  case invalidWorktreePath
+  case worktreeNotFound
+  case worktreeDirty
+  case createFailed(String)
 
-    var errorDescription: String? {
-        switch self {
-        case .invalidFolder:
-            return "The selected folder is invalid."
-        case .invalidBranchName:
-            return "Branch name cannot be empty."
-        case .invalidWorktreePath:
-            return "The selected worktree path is invalid."
-        case .worktreeNotFound:
-            return "That worktree does not belong to the selected repository."
-        case .worktreeDirty:
-            return "Worktree has local changes. Clean it before deletion."
-        case .createFailed(let message):
-            return message
-        }
+  var errorDescription: String? {
+    switch self {
+    case .invalidFolder:
+      "The selected folder is invalid."
+    case .invalidBranchName:
+      "Branch name cannot be empty."
+    case .invalidWorktreePath:
+      "The selected worktree path is invalid."
+    case .worktreeNotFound:
+      "That worktree does not belong to the selected repository."
+    case .worktreeDirty:
+      "Worktree has local changes. Clean it before deletion."
+    case let .createFailed(message):
+      message
     }
+  }
 }
 
 protocol WorktreeServiceProtocol {
-    func validateRepo(path: String) async throws -> GitRepoInfo
-    func createWorktree(repoPath: String, branchName: String?, sessionTitle: String?) async throws -> WorktreeInfo
-    func attachExistingWorktree(repoPath: String, worktreePath: String) async throws -> WorktreeInfo
-    func listWorktrees(repoPath: String) async throws -> [WorktreeInfo]
-    func inspectWorktree(repoPath: String, worktreePath: String) async throws -> WorktreeState
-    func deleteWorktreeIfClean(repoPath: String, worktreePath: String) async throws
+  func validateRepo(path: String) async throws -> GitRepoInfo
+  func createWorktree(repoPath: String, branchName: String?, sessionTitle: String?) async throws -> WorktreeInfo
+  func attachExistingWorktree(repoPath: String, worktreePath: String) async throws -> WorktreeInfo
+  func listWorktrees(repoPath: String) async throws -> [WorktreeInfo]
+  func inspectWorktree(repoPath: String, worktreePath: String) async throws -> WorktreeState
+  func deleteWorktreeIfClean(repoPath: String, worktreePath: String) async throws
 }
 
 struct WorktreeService: WorktreeServiceProtocol {
-    private let gitService: GitServiceProtocol
-    private let paths: FileSystemPaths
-    private let fileManager: FileManager
-    private let worktreeNameGenerator: () -> String
+  private let gitService: GitServiceProtocol
+  private let paths: FileSystemPaths
+  private let fileManager: FileManager
+  private let worktreeNameGenerator: () -> String
 
-    init(
-        gitService: GitServiceProtocol,
-        paths: FileSystemPaths,
-        fileManager: FileManager = .default,
-        worktreeNameGenerator: @escaping () -> String = {
-            String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(12)).lowercased()
-        }
-    ) {
-        self.gitService = gitService
-        self.paths = paths
-        self.fileManager = fileManager
-        self.worktreeNameGenerator = worktreeNameGenerator
+  init(
+    gitService: GitServiceProtocol,
+    paths: FileSystemPaths,
+    fileManager: FileManager = .default,
+    worktreeNameGenerator: @escaping () -> String = {
+      String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(12)).lowercased()
+    }
+  ) {
+    self.gitService = gitService
+    self.paths = paths
+    self.fileManager = fileManager
+    self.worktreeNameGenerator = worktreeNameGenerator
+  }
+
+  func validateRepo(path: String) async throws -> GitRepoInfo {
+    try await gitService.repoInfo(for: path)
+  }
+
+  func listWorktrees(repoPath: String) async throws -> [WorktreeInfo] {
+    try await gitService.listWorktrees(repoPath: repoPath)
+  }
+
+  func attachExistingWorktree(repoPath: String, worktreePath: String) async throws -> WorktreeInfo {
+    let info = try await gitService.repoInfo(for: repoPath)
+    let normalizedPath = URL(fileURLWithPath: worktreePath).standardizedFileURL.path
+
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: normalizedPath, isDirectory: &isDirectory),
+          isDirectory.boolValue
+    else {
+      throw WorktreeServiceError.invalidWorktreePath
     }
 
-    func validateRepo(path: String) async throws -> GitRepoInfo {
-        try await gitService.repoInfo(for: path)
+    let worktrees = try await gitService.listWorktrees(repoPath: info.topLevelPath)
+    guard let match = worktrees.first(where: {
+      URL(fileURLWithPath: $0.worktreePath).standardizedFileURL.path == normalizedPath
+    }) else {
+      throw WorktreeServiceError.worktreeNotFound
     }
 
-    func listWorktrees(repoPath: String) async throws -> [WorktreeInfo] {
-        try await gitService.listWorktrees(repoPath: repoPath)
+    return WorktreeInfo(
+      repoPath: info.topLevelPath,
+      worktreePath: match.worktreePath,
+      branchName: match.branchName
+    )
+  }
+
+  func createWorktree(repoPath: String, branchName: String?, sessionTitle: String?) async throws -> WorktreeInfo {
+    let info = try await gitService.repoInfo(for: repoPath)
+
+    let resolvedBranch: String = if let branchName,
+                                    !branchName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    {
+      branchName.trimmingCharacters(in: .whitespacesAndNewlines)
+    } else {
+      BranchNameGenerator.generate(
+        sessionTitle: sessionTitle,
+        repoName: info.repoName
+      )
     }
 
-    func attachExistingWorktree(repoPath: String, worktreePath: String) async throws -> WorktreeInfo {
-        let info = try await gitService.repoInfo(for: repoPath)
-        let normalizedPath = URL(fileURLWithPath: worktreePath).standardizedFileURL.path
-
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: normalizedPath, isDirectory: &isDirectory),
-              isDirectory.boolValue else {
-            throw WorktreeServiceError.invalidWorktreePath
-        }
-
-        let worktrees = try await gitService.listWorktrees(repoPath: info.topLevelPath)
-        guard let match = worktrees.first(where: {
-            URL(fileURLWithPath: $0.worktreePath).standardizedFileURL.path == normalizedPath
-        }) else {
-            throw WorktreeServiceError.worktreeNotFound
-        }
-
-        return WorktreeInfo(
-            repoPath: info.topLevelPath,
-            worktreePath: match.worktreePath,
-            branchName: match.branchName
-        )
+    guard !resolvedBranch.isEmpty else {
+      throw WorktreeServiceError.invalidBranchName
     }
 
-    func createWorktree(repoPath: String, branchName: String?, sessionTitle: String?) async throws -> WorktreeInfo {
-        let info = try await gitService.repoInfo(for: repoPath)
+    ensureIDX0ExcludedInLocalRepo(repoTopLevelPath: info.topLevelPath)
 
-        let resolvedBranch: String
-        if let branchName,
-           !branchName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            resolvedBranch = branchName.trimmingCharacters(in: .whitespacesAndNewlines)
-        } else {
-            resolvedBranch = BranchNameGenerator.generate(
-                sessionTitle: sessionTitle,
-                repoName: info.repoName
-            )
-        }
-
-        guard !resolvedBranch.isEmpty else {
-            throw WorktreeServiceError.invalidBranchName
-        }
-
-        ensureIDX0ExcludedInLocalRepo(repoTopLevelPath: info.topLevelPath)
-
-        let worktreePath: String
-        do {
-            worktreePath = try uniqueWorktreePath(repoTopLevelPath: info.topLevelPath)
-        } catch {
-            throw WorktreeServiceError.createFailed("Unable to prepare workspace worktree directory: \(error.localizedDescription)")
-        }
-
-        do {
-            return try await gitService.createWorktree(
-                repoPath: info.topLevelPath,
-                branchName: resolvedBranch,
-                worktreePath: worktreePath
-            )
-        } catch {
-            throw WorktreeServiceError.createFailed(error.localizedDescription)
-        }
+    let worktreePath: String
+    do {
+      worktreePath = try uniqueWorktreePath(repoTopLevelPath: info.topLevelPath)
+    } catch {
+      throw WorktreeServiceError.createFailed("Unable to prepare workspace worktree directory: \(error.localizedDescription)")
     }
 
-    func inspectWorktree(repoPath: String, worktreePath: String) async throws -> WorktreeState {
-        let info = try await gitService.repoInfo(for: repoPath)
-        let normalizedPath = URL(fileURLWithPath: worktreePath).standardizedFileURL.path
+    do {
+      return try await gitService.createWorktree(
+        repoPath: info.topLevelPath,
+        branchName: resolvedBranch,
+        worktreePath: worktreePath
+      )
+    } catch {
+      throw WorktreeServiceError.createFailed(error.localizedDescription)
+    }
+  }
 
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: normalizedPath, isDirectory: &isDirectory), isDirectory.boolValue else {
-            return .missingOnDisk
-        }
+  func inspectWorktree(repoPath: String, worktreePath: String) async throws -> WorktreeState {
+    let info = try await gitService.repoInfo(for: repoPath)
+    let normalizedPath = URL(fileURLWithPath: worktreePath).standardizedFileURL.path
 
-        let worktrees = try await gitService.listWorktrees(repoPath: info.topLevelPath)
-        guard worktrees.contains(where: {
-            URL(fileURLWithPath: $0.worktreePath).standardizedFileURL.path == normalizedPath
-        }) else {
-            throw WorktreeServiceError.worktreeNotFound
-        }
-
-        let status = try await gitService.statusPorcelain(path: normalizedPath)
-        return status.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? .clean : .dirty
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: normalizedPath, isDirectory: &isDirectory), isDirectory.boolValue else {
+      return .missingOnDisk
     }
 
-    func deleteWorktreeIfClean(repoPath: String, worktreePath: String) async throws {
-        let state = try await inspectWorktree(repoPath: repoPath, worktreePath: worktreePath)
-        switch state {
-        case .clean:
-            let info = try await gitService.repoInfo(for: repoPath)
-            try await gitService.removeWorktree(
-                repoPath: info.topLevelPath,
-                worktreePath: URL(fileURLWithPath: worktreePath).standardizedFileURL.path
-            )
-        case .dirty:
-            throw WorktreeServiceError.worktreeDirty
-        case .missingOnDisk:
-            throw WorktreeServiceError.invalidWorktreePath
-        default:
-            throw WorktreeServiceError.worktreeNotFound
-        }
+    let worktrees = try await gitService.listWorktrees(repoPath: info.topLevelPath)
+    guard worktrees.contains(where: {
+      URL(fileURLWithPath: $0.worktreePath).standardizedFileURL.path == normalizedPath
+    }) else {
+      throw WorktreeServiceError.worktreeNotFound
     }
 
-    private func uniqueWorktreePath(repoTopLevelPath: String) throws -> String {
-        let root = try workspaceWorktreesDirectoryURL(repoTopLevelPath: repoTopLevelPath)
-        let baseName = "wt-\(sanitizedWorktreeToken(worktreeNameGenerator()))"
-        var candidate = root.appendingPathComponent(baseName, isDirectory: true)
-        var suffix = 2
+    let status = try await gitService.statusPorcelain(path: normalizedPath)
+    return status.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? .clean : .dirty
+  }
 
-        while fileManager.fileExists(atPath: candidate.path) {
-            candidate = root.appendingPathComponent("\(baseName)-\(suffix)", isDirectory: true)
-            suffix += 1
-        }
+  func deleteWorktreeIfClean(repoPath: String, worktreePath: String) async throws {
+    let state = try await inspectWorktree(repoPath: repoPath, worktreePath: worktreePath)
+    switch state {
+    case .clean:
+      let info = try await gitService.repoInfo(for: repoPath)
+      try await gitService.removeWorktree(
+        repoPath: info.topLevelPath,
+        worktreePath: URL(fileURLWithPath: worktreePath).standardizedFileURL.path
+      )
+    case .dirty:
+      throw WorktreeServiceError.worktreeDirty
+    case .missingOnDisk:
+      throw WorktreeServiceError.invalidWorktreePath
+    default:
+      throw WorktreeServiceError.worktreeNotFound
+    }
+  }
 
-        return candidate.path
+  private func uniqueWorktreePath(repoTopLevelPath: String) throws -> String {
+    let root = try workspaceWorktreesDirectoryURL(repoTopLevelPath: repoTopLevelPath)
+    let baseName = "wt-\(sanitizedWorktreeToken(worktreeNameGenerator()))"
+    var candidate = root.appendingPathComponent(baseName, isDirectory: true)
+    var suffix = 2
+
+    while fileManager.fileExists(atPath: candidate.path) {
+      candidate = root.appendingPathComponent("\(baseName)-\(suffix)", isDirectory: true)
+      suffix += 1
     }
 
-    private func workspaceWorktreesDirectoryURL(repoTopLevelPath: String) throws -> URL {
-        let root = URL(fileURLWithPath: repoTopLevelPath)
-            .standardizedFileURL
-            .appendingPathComponent(".idx0", isDirectory: true)
-            .appendingPathComponent("worktrees", isDirectory: true)
-        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
-        return root
+    return candidate.path
+  }
+
+  private func workspaceWorktreesDirectoryURL(repoTopLevelPath: String) throws -> URL {
+    let root = URL(fileURLWithPath: repoTopLevelPath)
+      .standardizedFileURL
+      .appendingPathComponent(".idx0", isDirectory: true)
+      .appendingPathComponent("worktrees", isDirectory: true)
+    try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+    return root
+  }
+
+  private func sanitizedWorktreeToken(_ rawValue: String) -> String {
+    let token = rawValue.lowercased().filter { character in
+      ("a" ... "z").contains(character) || ("0" ... "9").contains(character)
+    }
+    if !token.isEmpty {
+      return String(token.prefix(12))
+    }
+    return String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(12)).lowercased()
+  }
+
+  private func ensureIDX0ExcludedInLocalRepo(repoTopLevelPath: String) {
+    guard let excludeFileURL = localGitExcludeURL(repoTopLevelPath: repoTopLevelPath) else {
+      return
     }
 
-    private func sanitizedWorktreeToken(_ rawValue: String) -> String {
-        let token = rawValue.lowercased().filter { character in
-            ("a"..."z").contains(character) || ("0"..."9").contains(character)
-        }
-        if !token.isEmpty {
-            return String(token.prefix(12))
-        }
-        return String(UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(12)).lowercased()
+    do {
+      try fileManager.createDirectory(
+        at: excludeFileURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+
+      let existing = (try? String(contentsOf: excludeFileURL, encoding: .utf8)) ?? ""
+      let entries = existing
+        .components(separatedBy: .newlines)
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      guard !entries.contains(".idx0/") else { return }
+
+      var updated = existing
+      if !updated.isEmpty, !updated.hasSuffix("\n") {
+        updated.append("\n")
+      }
+      updated.append(".idx0/\n")
+      try updated.write(to: excludeFileURL, atomically: true, encoding: .utf8)
+    } catch {
+      Logger.error("Failed to update local git exclude for .idx0/: \(error.localizedDescription)")
+    }
+  }
+
+  private func localGitExcludeURL(repoTopLevelPath: String) -> URL? {
+    guard let gitDirectory = gitDirectoryURL(repoTopLevelPath: repoTopLevelPath) else {
+      return nil
+    }
+    return gitDirectory
+      .appendingPathComponent("info", isDirectory: true)
+      .appendingPathComponent("exclude", isDirectory: false)
+  }
+
+  private func gitDirectoryURL(repoTopLevelPath: String) -> URL? {
+    let repoURL = URL(fileURLWithPath: repoTopLevelPath).standardizedFileURL
+    let dotGitURL = repoURL.appendingPathComponent(".git", isDirectory: false)
+
+    var isDirectory: ObjCBool = false
+    guard fileManager.fileExists(atPath: dotGitURL.path, isDirectory: &isDirectory) else {
+      return nil
     }
 
-    private func ensureIDX0ExcludedInLocalRepo(repoTopLevelPath: String) {
-        guard let excludeFileURL = localGitExcludeURL(repoTopLevelPath: repoTopLevelPath) else {
-            return
-        }
-
-        do {
-            try fileManager.createDirectory(
-                at: excludeFileURL.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-
-            let existing = (try? String(contentsOf: excludeFileURL, encoding: .utf8)) ?? ""
-            let entries = existing
-                .components(separatedBy: .newlines)
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            guard !entries.contains(".idx0/") else { return }
-
-            var updated = existing
-            if !updated.isEmpty, !updated.hasSuffix("\n") {
-                updated.append("\n")
-            }
-            updated.append(".idx0/\n")
-            try updated.write(to: excludeFileURL, atomically: true, encoding: .utf8)
-        } catch {
-            Logger.error("Failed to update local git exclude for .idx0/: \(error.localizedDescription)")
-        }
+    if isDirectory.boolValue {
+      return dotGitURL
     }
 
-    private func localGitExcludeURL(repoTopLevelPath: String) -> URL? {
-        guard let gitDirectory = gitDirectoryURL(repoTopLevelPath: repoTopLevelPath) else {
-            return nil
-        }
-        return gitDirectory
-            .appendingPathComponent("info", isDirectory: true)
-            .appendingPathComponent("exclude", isDirectory: false)
+    guard let dotGitContents = try? String(contentsOf: dotGitURL, encoding: .utf8),
+          let directiveLine = dotGitContents
+          .components(separatedBy: .newlines)
+          .first(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+    else {
+      return nil
     }
 
-    private func gitDirectoryURL(repoTopLevelPath: String) -> URL? {
-        let repoURL = URL(fileURLWithPath: repoTopLevelPath).standardizedFileURL
-        let dotGitURL = repoURL.appendingPathComponent(".git", isDirectory: false)
+    let trimmed = directiveLine.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.lowercased().hasPrefix("gitdir:") else { return nil }
 
-        var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: dotGitURL.path, isDirectory: &isDirectory) else {
-            return nil
-        }
+    let rawPath = String(trimmed.dropFirst("gitdir:".count)).trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !rawPath.isEmpty else { return nil }
 
-        if isDirectory.boolValue {
-            return dotGitURL
-        }
-
-        guard let dotGitContents = try? String(contentsOf: dotGitURL, encoding: .utf8),
-              let directiveLine = dotGitContents
-                .components(separatedBy: .newlines)
-                .first(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
-        else {
-            return nil
-        }
-
-        let trimmed = directiveLine.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.lowercased().hasPrefix("gitdir:") else { return nil }
-
-        let rawPath = String(trimmed.dropFirst("gitdir:".count)).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !rawPath.isEmpty else { return nil }
-
-        let resolved: URL
-        if rawPath.hasPrefix("/") {
-            resolved = URL(fileURLWithPath: rawPath, isDirectory: true)
-        } else {
-            resolved = repoURL.appendingPathComponent(rawPath, isDirectory: true)
-        }
-        return resolved.standardizedFileURL
+    let resolved: URL = if rawPath.hasPrefix("/") {
+      URL(fileURLWithPath: rawPath, isDirectory: true)
+    } else {
+      repoURL.appendingPathComponent(rawPath, isDirectory: true)
     }
+    return resolved.standardizedFileURL
+  }
 }

--- a/idx0/Services/Session/SessionService+Lifecycle.swift
+++ b/idx0/Services/Session/SessionService+Lifecycle.swift
@@ -41,22 +41,34 @@ extension SessionService {
     var worktreePath: String?
     var isWorktreeBacked = false
     var createdWorktree: WorktreeInfo?
+    let normalizedExistingWorktreePath = normalizePath(request.existingWorktreePath)
+    let explicitlyRequestedWorktree = request.createWorktree || normalizedExistingWorktreePath != nil
 
     if let normalizedRepo {
       branchName = request.branchName?.trimmingCharacters(in: .whitespacesAndNewlines)
       if branchName?.isEmpty == true { branchName = nil }
 
-      if request.createWorktree {
-        let repoInfo = try await worktreeService.validateRepo(path: normalizedRepo)
-        repoPath = repoInfo.topLevelPath
-        let worktree: WorktreeInfo = if let existingWorktreePath = normalizePath(request.existingWorktreePath) {
-          try await worktreeService.attachExistingWorktree(
-            repoPath: repoInfo.topLevelPath,
-            worktreePath: existingWorktreePath
+      let repoInfo = try? await worktreeService.validateRepo(path: normalizedRepo)
+      let shouldCreateWorktree = explicitlyRequestedWorktree
+        || (settings.defaultCreateWorktreeForRepoSessions && repoInfo != nil)
+
+      if shouldCreateWorktree {
+        let resolvedRepoInfo: GitRepoInfo
+        if let repoInfo {
+          resolvedRepoInfo = repoInfo
+        } else {
+          resolvedRepoInfo = try await worktreeService.validateRepo(path: normalizedRepo)
+        }
+        repoPath = resolvedRepoInfo.topLevelPath
+        let worktree: WorktreeInfo
+        if let normalizedExistingWorktreePath {
+          worktree = try await worktreeService.attachExistingWorktree(
+            repoPath: resolvedRepoInfo.topLevelPath,
+            worktreePath: normalizedExistingWorktreePath
           )
         } else {
-          try await worktreeService.createWorktree(
-            repoPath: repoInfo.topLevelPath,
+          worktree = try await worktreeService.createWorktree(
+            repoPath: resolvedRepoInfo.topLevelPath,
             branchName: branchName,
             sessionTitle: request.title
           )
@@ -66,7 +78,7 @@ extension SessionService {
         isWorktreeBacked = true
         createdWorktree = worktree
       } else {
-        if let repoInfo = try? await worktreeService.validateRepo(path: normalizedRepo) {
+        if let repoInfo {
           repoPath = repoInfo.topLevelPath
           if branchName == nil {
             branchName = repoInfo.currentBranch

--- a/idx0/Services/Session/SessionService+Lifecycle.swift
+++ b/idx0/Services/Session/SessionService+Lifecycle.swift
@@ -53,21 +53,19 @@ extension SessionService {
         || (settings.defaultCreateWorktreeForRepoSessions && repoInfo != nil)
 
       if shouldCreateWorktree {
-        let resolvedRepoInfo: GitRepoInfo
-        if let repoInfo {
-          resolvedRepoInfo = repoInfo
+        let resolvedRepoInfo: GitRepoInfo = if let repoInfo {
+          repoInfo
         } else {
-          resolvedRepoInfo = try await worktreeService.validateRepo(path: normalizedRepo)
+          try await worktreeService.validateRepo(path: normalizedRepo)
         }
         repoPath = resolvedRepoInfo.topLevelPath
-        let worktree: WorktreeInfo
-        if let normalizedExistingWorktreePath {
-          worktree = try await worktreeService.attachExistingWorktree(
+        let worktree: WorktreeInfo = if let normalizedExistingWorktreePath {
+          try await worktreeService.attachExistingWorktree(
             repoPath: resolvedRepoInfo.topLevelPath,
             worktreePath: normalizedExistingWorktreePath
           )
         } else {
-          worktree = try await worktreeService.createWorktree(
+          try await worktreeService.createWorktree(
             repoPath: resolvedRepoInfo.topLevelPath,
             branchName: branchName,
             sessionTitle: request.title

--- a/idx0/UI/Settings/Inline/InlineSessionSettings.swift
+++ b/idx0/UI/Settings/Inline/InlineSessionSettings.swift
@@ -3,76 +3,76 @@ import SwiftUI
 // MARK: - Sessions
 
 struct InlineSessionSettings: View {
-    @ObservedObject var sessionService: SessionService
-    @ObservedObject var workflowService: WorkflowService
-    @Environment(\.themeColors) private var tc
+  @ObservedObject var sessionService: SessionService
+  @ObservedObject var workflowService: WorkflowService
+  @Environment(\.themeColors) private var tc
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            SettingSectionHeader(title: "Behavior")
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      SettingSectionHeader(title: "Behavior")
 
-            SettingRowView(label: "New Session", caption: "Controls what happens when you press \u{2318}T. Quick creates an instant terminal, Structured opens the full setup dialog.") {
-                ThemedPicker(
-                    options: NewSessionBehavior.allCases.map { ($0.displayLabel, $0) },
-                    selection: enumBinding(\.newSessionBehavior)
-                )
-            }
+      SettingRowView(label: "New Session", caption: "Controls what happens when you press \u{2318}T. Quick creates an instant terminal, Structured opens the full setup dialog.") {
+        ThemedPicker(
+          options: NewSessionBehavior.allCases.map { ($0.displayLabel, $0) },
+          selection: enumBinding(\.newSessionBehavior)
+        )
+      }
 
-            SettingToggleRow(
-                label: "Create Worktree By Default",
-                caption: "When enabled, repo-backed sessions always create a worktree.",
-                isOn: binding(\.defaultCreateWorktreeForRepoSessions)
+      SettingToggleRow(
+        label: "Create Worktree By Default",
+        caption: "When enabled, repo-backed sessions always create a worktree.",
+        isOn: binding(\.defaultCreateWorktreeForRepoSessions)
+      )
+
+      SettingRowView(label: "Restore on Relaunch", caption: "What to bring back when IDX0 restarts.") {
+        ThemedPicker(
+          options: RestoreBehavior.allCases.map { ($0.displayLabel, $0) },
+          selection: enumBinding(\.restoreBehavior)
+        )
+      }
+
+      SettingToggleRow(
+        label: "Cleanup On Close",
+        caption: "When enabled, tile layouts are cleared when a session is closed. When disabled, open tiles are restored on next launch.",
+        isOn: binding(\.cleanupOnClose)
+      )
+
+      if sessionService.settings.appMode.showsVibeFeatures {
+        SettingDivider()
+        SettingSectionHeader(title: "Vibe Tools")
+
+        SettingRowView(label: "Default Tool", caption: "The agentic CLI to auto-launch in new sessions.") {
+          ThemedPicker(
+            options: [("None", "none")] + workflowService.vibeTools.map {
+              ($0.isInstalled ? $0.displayName : "\($0.displayName) (N/A)", $0.id)
+            },
+            selection: Binding(
+              get: { sessionService.settings.defaultVibeToolID ?? "none" },
+              set: { value in sessionService.saveSettings { $0.defaultVibeToolID = value == "none" ? nil : value } }
             )
-
-            SettingRowView(label: "Restore on Relaunch", caption: "What to bring back when IDX0 restarts.") {
-                ThemedPicker(
-                    options: RestoreBehavior.allCases.map { ($0.displayLabel, $0) },
-                    selection: enumBinding(\.restoreBehavior)
-                )
-            }
-
-            SettingToggleRow(
-                label: "Cleanup On Close",
-                caption: "When enabled, tile layouts are cleared when a session is closed. When disabled, open tiles are restored on next launch.",
-                isOn: binding(\.cleanupOnClose)
-            )
-
-            if sessionService.settings.appMode.showsVibeFeatures {
-                SettingDivider()
-                SettingSectionHeader(title: "Vibe Tools")
-
-                SettingRowView(label: "Default Tool", caption: "The agentic CLI to auto-launch in new sessions.") {
-                    ThemedPicker(
-                        options: [("None", "none")] + workflowService.vibeTools.map {
-                            ($0.isInstalled ? $0.displayName : "\($0.displayName) (N/A)", $0.id)
-                        },
-                        selection: Binding(
-                            get: { sessionService.settings.defaultVibeToolID ?? "none" },
-                            set: { value in sessionService.saveSettings { $0.defaultVibeToolID = value == "none" ? nil : value } }
-                        )
-                    )
-                }
-
-                SettingToggleRow(
-                    label: "Auto-Launch on \u{2318}N",
-                    caption: nil,
-                    isOn: binding(\.autoLaunchDefaultVibeToolOnCmdN)
-                )
-            }
+          )
         }
-    }
 
-    private func binding(_ keyPath: WritableKeyPath<AppSettings, Bool>) -> Binding<Bool> {
-        Binding(
-            get: { sessionService.settings[keyPath: keyPath] },
-            set: { value in sessionService.saveSettings { $0[keyPath: keyPath] = value } }
+        SettingToggleRow(
+          label: "Auto-Launch on \u{2318}N",
+          caption: nil,
+          isOn: binding(\.autoLaunchDefaultVibeToolOnCmdN)
         )
+      }
     }
+  }
 
-    private func enumBinding<Value: Hashable>(_ keyPath: WritableKeyPath<AppSettings, Value>) -> Binding<Value> {
-        Binding(
-            get: { sessionService.settings[keyPath: keyPath] },
-            set: { value in sessionService.saveSettings { $0[keyPath: keyPath] = value } }
-        )
-    }
+  private func binding(_ keyPath: WritableKeyPath<AppSettings, Bool>) -> Binding<Bool> {
+    Binding(
+      get: { sessionService.settings[keyPath: keyPath] },
+      set: { value in sessionService.saveSettings { $0[keyPath: keyPath] = value } }
+    )
+  }
+
+  private func enumBinding<Value: Hashable>(_ keyPath: WritableKeyPath<AppSettings, Value>) -> Binding<Value> {
+    Binding(
+      get: { sessionService.settings[keyPath: keyPath] },
+      set: { value in sessionService.saveSettings { $0[keyPath: keyPath] = value } }
+    )
+  }
 }

--- a/idx0/UI/Settings/Inline/InlineSessionSettings.swift
+++ b/idx0/UI/Settings/Inline/InlineSessionSettings.swift
@@ -20,7 +20,7 @@ struct InlineSessionSettings: View {
 
             SettingToggleRow(
                 label: "Create Worktree By Default",
-                caption: "Automatically enable git worktree creation when opening repo-backed sessions.",
+                caption: "When enabled, repo-backed sessions always create a worktree.",
                 isOn: binding(\.defaultCreateWorktreeForRepoSessions)
             )
 

--- a/idx0/UI/Settings/Tabs/SessionSettingsTab.swift
+++ b/idx0/UI/Settings/Tabs/SessionSettingsTab.swift
@@ -3,94 +3,94 @@ import SwiftUI
 // MARK: - Sessions Tab
 
 struct SessionSettingsTab: View {
-    @ObservedObject var sessionService: SessionService
-    @ObservedObject var workflowService: WorkflowService
+  @ObservedObject var sessionService: SessionService
+  @ObservedObject var workflowService: WorkflowService
 
-    var body: some View {
-        Form {
-            Section("Behavior") {
-                Picker("New Session Behavior", selection: enumBinding(\.newSessionBehavior)) {
-                    ForEach(NewSessionBehavior.allCases, id: \.self) { behavior in
-                        Text(behavior.displayLabel).tag(behavior)
-                    }
-                }
-                Text("What happens when you press \u{2318}T")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Toggle(
-                        "Create Worktree By Default For Repo Sessions",
-                        isOn: binding(\.defaultCreateWorktreeForRepoSessions)
-                    )
-                    Text("When enabled, repo-backed sessions always create a worktree")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
-
-                Picker("Restore Behavior", selection: enumBinding(\.restoreBehavior)) {
-                    ForEach(RestoreBehavior.allCases, id: \.self) { behavior in
-                        Text(behavior.displayLabel).tag(behavior)
-                    }
-                }
-                Text("What to restore when IDX0 relaunches")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Toggle(
-                        "Cleanup On Close",
-                        isOn: binding(\.cleanupOnClose)
-                    )
-                    Text("When off, open tiles are restored next launch. When on, tile layouts are cleared on app close.")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                }
-            }
-
-            if sessionService.settings.appMode.showsVibeFeatures {
-                Section("Vibe Tools") {
-                    Picker(
-                        "Default Vibe Tool",
-                        selection: Binding(
-                            get: { sessionService.settings.defaultVibeToolID ?? "none" },
-                            set: { value in sessionService.saveSettings { $0.defaultVibeToolID = value == "none" ? nil : value } }
-                        )
-                    ) {
-                        Text("None").tag("none")
-                        ForEach(workflowService.vibeTools, id: \.id) { tool in
-                            Text(tool.isInstalled ? tool.displayName : "\(tool.displayName) (Not Installed)")
-                                .tag(tool.id)
-                        }
-                    }
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Toggle(
-                            "Cmd+N Auto-Launch Default Vibe Tool",
-                            isOn: binding(\.autoLaunchDefaultVibeToolOnCmdN)
-                        )
-                        Text("Automatically start the default vibe tool when creating a session with \u{2318}N")
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
-                    }
-                }
-            }
+  var body: some View {
+    Form {
+      Section("Behavior") {
+        Picker("New Session Behavior", selection: enumBinding(\.newSessionBehavior)) {
+          ForEach(NewSessionBehavior.allCases, id: \.self) { behavior in
+            Text(behavior.displayLabel).tag(behavior)
+          }
         }
-        .formStyle(.grouped)
-        .padding(10)
-    }
+        Text("What happens when you press \u{2318}T")
+          .font(.caption)
+          .foregroundStyle(.tertiary)
 
-    private func binding(_ keyPath: WritableKeyPath<AppSettings, Bool>) -> Binding<Bool> {
-        Binding(
-            get: { sessionService.settings[keyPath: keyPath] },
-            set: { value in sessionService.saveSettings { $0[keyPath: keyPath] = value } }
-        )
-    }
+        VStack(alignment: .leading, spacing: 4) {
+          Toggle(
+            "Create Worktree By Default For Repo Sessions",
+            isOn: binding(\.defaultCreateWorktreeForRepoSessions)
+          )
+          Text("When enabled, repo-backed sessions always create a worktree")
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+        }
 
-    private func enumBinding<Value: Hashable>(_ keyPath: WritableKeyPath<AppSettings, Value>) -> Binding<Value> {
-        Binding(
-            get: { sessionService.settings[keyPath: keyPath] },
-            set: { value in sessionService.saveSettings { $0[keyPath: keyPath] = value } }
-        )
+        Picker("Restore Behavior", selection: enumBinding(\.restoreBehavior)) {
+          ForEach(RestoreBehavior.allCases, id: \.self) { behavior in
+            Text(behavior.displayLabel).tag(behavior)
+          }
+        }
+        Text("What to restore when IDX0 relaunches")
+          .font(.caption)
+          .foregroundStyle(.tertiary)
+
+        VStack(alignment: .leading, spacing: 4) {
+          Toggle(
+            "Cleanup On Close",
+            isOn: binding(\.cleanupOnClose)
+          )
+          Text("When off, open tiles are restored next launch. When on, tile layouts are cleared on app close.")
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+        }
+      }
+
+      if sessionService.settings.appMode.showsVibeFeatures {
+        Section("Vibe Tools") {
+          Picker(
+            "Default Vibe Tool",
+            selection: Binding(
+              get: { sessionService.settings.defaultVibeToolID ?? "none" },
+              set: { value in sessionService.saveSettings { $0.defaultVibeToolID = value == "none" ? nil : value } }
+            )
+          ) {
+            Text("None").tag("none")
+            ForEach(workflowService.vibeTools, id: \.id) { tool in
+              Text(tool.isInstalled ? tool.displayName : "\(tool.displayName) (Not Installed)")
+                .tag(tool.id)
+            }
+          }
+
+          VStack(alignment: .leading, spacing: 4) {
+            Toggle(
+              "Cmd+N Auto-Launch Default Vibe Tool",
+              isOn: binding(\.autoLaunchDefaultVibeToolOnCmdN)
+            )
+            Text("Automatically start the default vibe tool when creating a session with \u{2318}N")
+              .font(.caption)
+              .foregroundStyle(.tertiary)
+          }
+        }
+      }
     }
+    .formStyle(.grouped)
+    .padding(10)
+  }
+
+  private func binding(_ keyPath: WritableKeyPath<AppSettings, Bool>) -> Binding<Bool> {
+    Binding(
+      get: { sessionService.settings[keyPath: keyPath] },
+      set: { value in sessionService.saveSettings { $0[keyPath: keyPath] = value } }
+    )
+  }
+
+  private func enumBinding<Value: Hashable>(_ keyPath: WritableKeyPath<AppSettings, Value>) -> Binding<Value> {
+    Binding(
+      get: { sessionService.settings[keyPath: keyPath] },
+      set: { value in sessionService.saveSettings { $0[keyPath: keyPath] = value } }
+    )
+  }
 }

--- a/idx0/UI/Settings/Tabs/SessionSettingsTab.swift
+++ b/idx0/UI/Settings/Tabs/SessionSettingsTab.swift
@@ -23,7 +23,7 @@ struct SessionSettingsTab: View {
                         "Create Worktree By Default For Repo Sessions",
                         isOn: binding(\.defaultCreateWorktreeForRepoSessions)
                     )
-                    Text("Automatically enable worktree creation when a git repo is selected")
+                    Text("When enabled, repo-backed sessions always create a worktree")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                 }

--- a/idx0/UI/Sheets/NewSessionSheet.swift
+++ b/idx0/UI/Sheets/NewSessionSheet.swift
@@ -2,483 +2,482 @@ import AppKit
 import SwiftUI
 
 struct NewSessionSheet: View {
-    @EnvironmentObject private var coordinator: AppCoordinator
-    @EnvironmentObject private var sessionService: SessionService
-    @EnvironmentObject private var workflowService: WorkflowService
+  @EnvironmentObject private var coordinator: AppCoordinator
+  @EnvironmentObject private var sessionService: SessionService
+  @EnvironmentObject private var workflowService: WorkflowService
 
-    let preset: NewSessionPreset
+  let preset: NewSessionPreset
 
-    @State private var title = ""
-    @State private var folderPath = ""
-    @State private var createWorktree = false
-    @State private var branchName = ""
-    @State private var repoBranchMode: RepoBranchMode = .current
-    @State private var useExistingWorktree = false
-    @State private var existingWorktreePath = ""
-    @State private var shellPath = ""
-    @State private var launchMode: LaunchMode = .plainShell
-    @State private var selectedToolID = ""
-    @State private var sandboxProfile: SandboxProfile = .fullAccess
-    @State private var networkPolicy: NetworkPolicy = .inherited
-    @State private var isCreating = false
-    @State private var isCheckingRepo = false
-    @State private var folderIsGitRepo = false
-    @State private var showGitSection = false
-    @State private var showSafetySection = false
-    @State private var showVibeSection = false
-    @State private var showAdvanced = false
-    @State private var repoCheckToken = UUID()
-    @State private var errorMessage: String?
+  @State private var title = ""
+  @State private var folderPath = ""
+  @State private var createWorktree = false
+  @State private var branchName = ""
+  @State private var repoBranchMode: RepoBranchMode = .current
+  @State private var useExistingWorktree = false
+  @State private var existingWorktreePath = ""
+  @State private var shellPath = ""
+  @State private var launchMode: LaunchMode = .plainShell
+  @State private var selectedToolID = ""
+  @State private var sandboxProfile: SandboxProfile = .fullAccess
+  @State private var networkPolicy: NetworkPolicy = .inherited
+  @State private var isCreating = false
+  @State private var isCheckingRepo = false
+  @State private var folderIsGitRepo = false
+  @State private var showGitSection = false
+  @State private var showSafetySection = false
+  @State private var showVibeSection = false
+  @State private var showAdvanced = false
+  @State private var repoCheckToken = UUID()
+  @State private var errorMessage: String?
 
-    private var showsVibeFeatures: Bool {
-        sessionService.settings.appMode.showsVibeFeatures
-    }
+  private var showsVibeFeatures: Bool {
+    sessionService.settings.appMode.showsVibeFeatures
+  }
 
-    private var settingForcesWorktree: Bool {
-        sessionService.settings.defaultCreateWorktreeForRepoSessions && folderIsGitRepo
-    }
+  private var settingForcesWorktree: Bool {
+    sessionService.settings.defaultCreateWorktreeForRepoSessions && folderIsGitRepo
+  }
 
-    private var effectiveCreateWorktree: Bool {
-        settingForcesWorktree || createWorktree
-    }
+  private var effectiveCreateWorktree: Bool {
+    settingForcesWorktree || createWorktree
+  }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text("Create Session")
-                .font(.title3.weight(.semibold))
+  var body: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      Text("Create Session")
+        .font(.title3.weight(.semibold))
 
-            // MARK: - Tier 1: Always visible
+      // MARK: - Tier 1: Always visible
 
-            TextField("Session name (optional)", text: $title)
+      TextField("Session name (optional)", text: $title)
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Folder")
+      VStack(alignment: .leading, spacing: 6) {
+        Text("Folder")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        HStack {
+          TextField("Optional project folder", text: $folderPath)
+          Button("Choose\u{2026}") {
+            chooseFolder()
+          }
+        }
+      }
+
+      // MARK: - Git & Worktree Section (auto-revealed when git repo detected)
+
+      if folderIsGitRepo || preset == .worktree {
+        sectionCard {
+          VStack(alignment: .leading, spacing: 10) {
+            sectionToggleHeader(
+              icon: "arrow.triangle.branch",
+              title: "Git & Worktree",
+              isExpanded: $showGitSection
+            )
+
+            if showGitSection {
+              Toggle("Create worktree", isOn: $createWorktree)
+                .disabled(settingForcesWorktree)
+
+              if settingForcesWorktree {
+                Text("Worktree creation is enforced. Disable it in Settings > Sessions.")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+              }
+
+              if effectiveCreateWorktree {
+                if isCheckingRepo {
+                  HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text("Checking repository\u{2026}")
+                      .font(.caption)
+                      .foregroundStyle(.secondary)
+                  }
+                } else if folderIsGitRepo {
+                  Picker("Worktree mode", selection: $useExistingWorktree) {
+                    Text("Create New").tag(false)
+                    Text("Attach Existing").tag(true)
+                  }
+                  .pickerStyle(.segmented)
+
+                  if useExistingWorktree {
+                    VStack(alignment: .leading, spacing: 6) {
+                      Text("Existing worktree")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                      HStack {
+                        TextField("Worktree path", text: $existingWorktreePath)
+                        Button("Choose\u{2026}") { chooseExistingWorktree() }
+                      }
+                    }
+                  } else {
+                    TextField("Branch name (optional)", text: $branchName)
+                  }
+                } else {
+                  Text("Select a Git repository folder to enable worktree options.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                HStack {
-                    TextField("Optional project folder", text: $folderPath)
-                    Button("Choose\u{2026}") {
-                        chooseFolder()
-                    }
                 }
-            }
+              }
 
-            // MARK: - Git & Worktree Section (auto-revealed when git repo detected)
-
-            if folderIsGitRepo || preset == .worktree {
-                sectionCard {
-                    VStack(alignment: .leading, spacing: 10) {
-                        sectionToggleHeader(
-                            icon: "arrow.triangle.branch",
-                            title: "Git & Worktree",
-                            isExpanded: $showGitSection
-                        )
-
-                        if showGitSection {
-                            Toggle("Create worktree", isOn: $createWorktree)
-                                .disabled(settingForcesWorktree)
-
-                            if settingForcesWorktree {
-                                Text("Worktree creation is enforced. Disable it in Settings > Sessions.")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-
-                            if effectiveCreateWorktree {
-                                if isCheckingRepo {
-                                    HStack(spacing: 8) {
-                                        ProgressView().controlSize(.small)
-                                        Text("Checking repository\u{2026}")
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                    }
-                                } else if folderIsGitRepo {
-                                    Picker("Worktree mode", selection: $useExistingWorktree) {
-                                        Text("Create New").tag(false)
-                                        Text("Attach Existing").tag(true)
-                                    }
-                                    .pickerStyle(.segmented)
-
-                                    if useExistingWorktree {
-                                        VStack(alignment: .leading, spacing: 6) {
-                                            Text("Existing worktree")
-                                                .font(.caption)
-                                                .foregroundStyle(.secondary)
-                                            HStack {
-                                                TextField("Worktree path", text: $existingWorktreePath)
-                                                Button("Choose\u{2026}") { chooseExistingWorktree() }
-                                            }
-                                        }
-                                    } else {
-                                        TextField("Branch name (optional)", text: $branchName)
-                                    }
-                                } else {
-                                    Text("Select a Git repository folder to enable worktree options.")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
-                            }
-
-                            if !effectiveCreateWorktree, folderIsGitRepo {
-                                VStack(alignment: .leading, spacing: 6) {
-                                    Text("Branch mode")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                    Picker("Branch mode", selection: $repoBranchMode) {
-                                        Text("Use Current").tag(RepoBranchMode.current)
-                                        Text("Set Manually").tag(RepoBranchMode.custom)
-                                    }
-                                    .pickerStyle(.segmented)
-
-                                    if repoBranchMode == .custom {
-                                        TextField("Branch name", text: $branchName)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                .animation(.easeInOut(duration: 0.2), value: showGitSection)
-            }
-
-            // MARK: - Safety Section (collapsed by default)
-
-            sectionCard {
-                VStack(alignment: .leading, spacing: 10) {
-                    sectionToggleHeader(
-                        icon: "shield",
-                        title: "Safety",
-                        isExpanded: $showSafetySection
-                    )
-
-                    if showSafetySection {
-                        Picker("Sandbox profile", selection: $sandboxProfile) {
-                            ForEach(SandboxProfile.allCases, id: \.self) { profile in
-                                Text(profile.displayLabel).tag(profile)
-                            }
-                        }
-
-                        Picker("Network policy", selection: $networkPolicy) {
-                            ForEach(NetworkPolicy.allCases, id: \.self) { policy in
-                                Text(policy.displayLabel).tag(policy)
-                            }
-                        }
-                        .pickerStyle(.segmented)
-                    }
-                }
-            }
-            .animation(.easeInOut(duration: 0.2), value: showSafetySection)
-
-            // MARK: - Vibe Tool Section (hidden in terminal mode)
-
-            if showsVibeFeatures {
-                sectionCard {
-                    VStack(alignment: .leading, spacing: 10) {
-                        sectionToggleHeader(
-                            icon: "wand.and.stars",
-                            title: "Vibe Tool",
-                            isExpanded: $showVibeSection
-                        )
-
-                        if showVibeSection {
-                            Picker("Launch mode", selection: $launchMode) {
-                                Text("Plain Shell").tag(LaunchMode.plainShell)
-                                Text("Auto-Start Tool").tag(LaunchMode.autoTool)
-                            }
-                            .pickerStyle(.segmented)
-
-                            if launchMode == .autoTool {
-                                Picker("Tool", selection: $selectedToolID) {
-                                    ForEach(workflowService.vibeTools, id: \.id) { tool in
-                                        Text(tool.isInstalled ? tool.displayName : "\(tool.displayName) (Not Installed)")
-                                            .tag(tool.id)
-                                    }
-                                }
-                                .disabled(workflowService.vibeTools.isEmpty)
-                            }
-                        }
-                    }
-                }
-                .animation(.easeInOut(duration: 0.2), value: showVibeSection)
-            }
-
-            // MARK: - Advanced
-
-            DisclosureGroup("Advanced", isExpanded: $showAdvanced) {
-                TextField("Shell path (optional)", text: $shellPath)
-                    .textFieldStyle(.roundedBorder)
-                    .padding(.top, 6)
-            }
-
-            if let errorMessage {
-                Text(errorMessage)
-                    .foregroundStyle(.red)
+              if !effectiveCreateWorktree, folderIsGitRepo {
+                VStack(alignment: .leading, spacing: 6) {
+                  Text("Branch mode")
                     .font(.caption)
+                    .foregroundStyle(.secondary)
+                  Picker("Branch mode", selection: $repoBranchMode) {
+                    Text("Use Current").tag(RepoBranchMode.current)
+                    Text("Set Manually").tag(RepoBranchMode.custom)
+                  }
+                  .pickerStyle(.segmented)
+
+                  if repoBranchMode == .custom {
+                    TextField("Branch name", text: $branchName)
+                  }
+                }
+              }
+            }
+          }
+        }
+        .animation(.easeInOut(duration: 0.2), value: showGitSection)
+      }
+
+      // MARK: - Safety Section (collapsed by default)
+
+      sectionCard {
+        VStack(alignment: .leading, spacing: 10) {
+          sectionToggleHeader(
+            icon: "shield",
+            title: "Safety",
+            isExpanded: $showSafetySection
+          )
+
+          if showSafetySection {
+            Picker("Sandbox profile", selection: $sandboxProfile) {
+              ForEach(SandboxProfile.allCases, id: \.self) { profile in
+                Text(profile.displayLabel).tag(profile)
+              }
             }
 
-            HStack {
-                Spacer()
-                Button("Cancel") {
-                    coordinator.showingNewSessionSheet = false
-                }
-                .keyboardShortcut(.cancelAction)
+            Picker("Network policy", selection: $networkPolicy) {
+              ForEach(NetworkPolicy.allCases, id: \.self) { policy in
+                Text(policy.displayLabel).tag(policy)
+              }
+            }
+            .pickerStyle(.segmented)
+          }
+        }
+      }
+      .animation(.easeInOut(duration: 0.2), value: showSafetySection)
 
-                Button(isCreating ? "Creating\u{2026}" : "Create Session") {
-                    createSession()
+      // MARK: - Vibe Tool Section (hidden in terminal mode)
+
+      if showsVibeFeatures {
+        sectionCard {
+          VStack(alignment: .leading, spacing: 10) {
+            sectionToggleHeader(
+              icon: "wand.and.stars",
+              title: "Vibe Tool",
+              isExpanded: $showVibeSection
+            )
+
+            if showVibeSection {
+              Picker("Launch mode", selection: $launchMode) {
+                Text("Plain Shell").tag(LaunchMode.plainShell)
+                Text("Auto-Start Tool").tag(LaunchMode.autoTool)
+              }
+              .pickerStyle(.segmented)
+
+              if launchMode == .autoTool {
+                Picker("Tool", selection: $selectedToolID) {
+                  ForEach(workflowService.vibeTools, id: \.id) { tool in
+                    Text(tool.isInstalled ? tool.displayName : "\(tool.displayName) (Not Installed)")
+                      .tag(tool.id)
+                  }
                 }
-                .keyboardShortcut(.defaultAction)
-                .disabled(isCreateDisabled)
+                .disabled(workflowService.vibeTools.isEmpty)
+              }
             }
+          }
         }
-        .padding(18)
-        .onAppear {
-            configurePresetDefaults()
-            refreshRepoStatus()
-            workflowService.refreshVibeTools()
-            if selectedToolID.isEmpty {
-                selectedToolID = sessionService.settings.defaultVibeToolID ?? workflowService.vibeTools.first?.id ?? ""
-            }
+        .animation(.easeInOut(duration: 0.2), value: showVibeSection)
+      }
+
+      // MARK: - Advanced
+
+      DisclosureGroup("Advanced", isExpanded: $showAdvanced) {
+        TextField("Shell path (optional)", text: $shellPath)
+          .textFieldStyle(.roundedBorder)
+          .padding(.top, 6)
+      }
+
+      if let errorMessage {
+        Text(errorMessage)
+          .foregroundStyle(.red)
+          .font(.caption)
+      }
+
+      HStack {
+        Spacer()
+        Button("Cancel") {
+          coordinator.showingNewSessionSheet = false
         }
-        .onChange(of: folderPath) {
-            refreshRepoStatus()
+        .keyboardShortcut(.cancelAction)
+
+        Button(isCreating ? "Creating\u{2026}" : "Create Session") {
+          createSession()
         }
-        .onChange(of: folderIsGitRepo) { _, isRepo in
-            if isRepo {
-                showGitSection = true
-                if sessionService.settings.defaultCreateWorktreeForRepoSessions {
-                    createWorktree = true
-                }
-            }
+        .keyboardShortcut(.defaultAction)
+        .disabled(isCreateDisabled)
+      }
+    }
+    .padding(18)
+    .onAppear {
+      configurePresetDefaults()
+      refreshRepoStatus()
+      workflowService.refreshVibeTools()
+      if selectedToolID.isEmpty {
+        selectedToolID = sessionService.settings.defaultVibeToolID ?? workflowService.vibeTools.first?.id ?? ""
+      }
+    }
+    .onChange(of: folderPath) {
+      refreshRepoStatus()
+    }
+    .onChange(of: folderIsGitRepo) { _, isRepo in
+      if isRepo {
+        showGitSection = true
+        if sessionService.settings.defaultCreateWorktreeForRepoSessions {
+          createWorktree = true
         }
-        .onChange(of: createWorktree) {
-            if createWorktree {
-                refreshRepoStatus()
-                prefillBranchIfNeeded()
-            } else {
-                useExistingWorktree = false
-                existingWorktreePath = ""
-                if repoBranchMode == .current {
-                    branchName = ""
-                }
-            }
+      }
+    }
+    .onChange(of: createWorktree) {
+      if createWorktree {
+        refreshRepoStatus()
+        prefillBranchIfNeeded()
+      } else {
+        useExistingWorktree = false
+        existingWorktreePath = ""
+        if repoBranchMode == .current {
+          branchName = ""
         }
-        .onChange(of: useExistingWorktree) {
-            if useExistingWorktree {
-                branchName = ""
-            } else {
-                prefillBranchIfNeeded()
-            }
-        }
-        .onChange(of: repoBranchMode) {
-            if repoBranchMode == .current && !createWorktree {
-                branchName = ""
-            }
-        }
+      }
+    }
+    .onChange(of: useExistingWorktree) {
+      if useExistingWorktree {
+        branchName = ""
+      } else {
+        prefillBranchIfNeeded()
+      }
+    }
+    .onChange(of: repoBranchMode) {
+      if repoBranchMode == .current, !createWorktree {
+        branchName = ""
+      }
+    }
+  }
+
+  // MARK: - Section Card Components
+
+  private func sectionCard(@ViewBuilder content: () -> some View) -> some View {
+    content()
+      .padding(12)
+      .background(.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 8))
+  }
+
+  private func sectionToggleHeader(icon: String, title: String, isExpanded: Binding<Bool>) -> some View {
+    Button {
+      withAnimation(.easeInOut(duration: 0.2)) {
+        isExpanded.wrappedValue.toggle()
+      }
+    } label: {
+      HStack(spacing: 6) {
+        Image(systemName: icon)
+          .font(.system(size: 10, weight: .medium))
+          .foregroundStyle(.white.opacity(0.4))
+          .frame(width: 16)
+
+        Text(title)
+          .font(.system(size: 11, weight: .semibold))
+          .foregroundStyle(.white.opacity(0.7))
+
+        Spacer()
+
+        Image(systemName: isExpanded.wrappedValue ? "chevron.up" : "chevron.down")
+          .font(.system(size: 8, weight: .semibold))
+          .foregroundStyle(.white.opacity(0.3))
+      }
+    }
+    .buttonStyle(.plain)
+  }
+
+  // MARK: - Logic
+
+  private var isCreateDisabled: Bool {
+    if isCreating || isCheckingRepo {
+      return true
+    }
+    if effectiveCreateWorktree, !folderIsGitRepo {
+      return true
+    }
+    if effectiveCreateWorktree, useExistingWorktree, existingWorktreePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      return true
+    }
+    if !effectiveCreateWorktree,
+       folderIsGitRepo,
+       repoBranchMode == .custom,
+       branchName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    {
+      return true
+    }
+    if launchMode == .autoTool {
+      guard !selectedToolID.isEmpty else { return true }
+      let installed = workflowService.vibeTools.first(where: { $0.id == selectedToolID })?.isInstalled ?? false
+      if !installed { return true }
+    }
+    return false
+  }
+
+  private func configurePresetDefaults() {
+    createWorktree = sessionService.settings.defaultCreateWorktreeForRepoSessions
+    sandboxProfile = sessionService.settings.defaultSandboxProfile
+    networkPolicy = sessionService.settings.defaultNetworkPolicy
+    if preset == .quick {
+      folderPath = ""
+      createWorktree = false
+    } else if preset == .worktree {
+      createWorktree = true
+      showGitSection = true
+    }
+  }
+
+  private func chooseFolder() {
+    let panel = NSOpenPanel()
+    panel.canChooseDirectories = true
+    panel.canChooseFiles = false
+    panel.allowsMultipleSelection = false
+    panel.canCreateDirectories = false
+    if panel.runModal() == .OK {
+      folderPath = panel.url?.path ?? ""
+      prefillBranchIfNeeded()
+    }
+  }
+
+  private func chooseExistingWorktree() {
+    let panel = NSOpenPanel()
+    panel.canChooseDirectories = true
+    panel.canChooseFiles = false
+    panel.allowsMultipleSelection = false
+    panel.canCreateDirectories = false
+    if panel.runModal() == .OK {
+      existingWorktreePath = panel.url?.path ?? ""
+    }
+  }
+
+  private func prefillBranchIfNeeded() {
+    guard effectiveCreateWorktree, folderIsGitRepo, !useExistingWorktree else { return }
+    guard branchName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+    let repoName = URL(fileURLWithPath: folderPath).lastPathComponent
+    branchName = BranchNameGenerator.generate(
+      sessionTitle: title.isEmpty ? nil : title,
+      repoName: repoName
+    )
+  }
+
+  private func refreshRepoStatus() {
+    let cleanedFolder = folderPath.trimmingCharacters(in: .whitespacesAndNewlines)
+    let token = UUID()
+    repoCheckToken = token
+
+    guard !cleanedFolder.isEmpty else {
+      isCheckingRepo = false
+      folderIsGitRepo = false
+      repoBranchMode = .current
+      branchName = ""
+      useExistingWorktree = false
+      existingWorktreePath = ""
+      return
     }
 
-    // MARK: - Section Card Components
-
-    @ViewBuilder
-    private func sectionCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        content()
-            .padding(12)
-            .background(.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 8))
-    }
-
-    @ViewBuilder
-    private func sectionToggleHeader(icon: String, title: String, isExpanded: Binding<Bool>) -> some View {
-        Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isExpanded.wrappedValue.toggle()
-            }
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: icon)
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.4))
-                    .frame(width: 16)
-
-                Text(title)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.7))
-
-                Spacer()
-
-                Image(systemName: isExpanded.wrappedValue ? "chevron.up" : "chevron.down")
-                    .font(.system(size: 8, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.3))
-            }
-        }
-        .buttonStyle(.plain)
-    }
-
-    // MARK: - Logic
-
-    private var isCreateDisabled: Bool {
-        if isCreating || isCheckingRepo {
-            return true
-        }
-        if effectiveCreateWorktree && !folderIsGitRepo {
-            return true
-        }
-        if effectiveCreateWorktree && useExistingWorktree && existingWorktreePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return true
-        }
-        if !effectiveCreateWorktree &&
-            folderIsGitRepo &&
-            repoBranchMode == .custom &&
-            branchName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return true
-        }
-        if launchMode == .autoTool {
-            guard !selectedToolID.isEmpty else { return true }
-            let installed = workflowService.vibeTools.first(where: { $0.id == selectedToolID })?.isInstalled ?? false
-            if !installed { return true }
-        }
-        return false
-    }
-
-    private func configurePresetDefaults() {
-        createWorktree = sessionService.settings.defaultCreateWorktreeForRepoSessions
-        sandboxProfile = sessionService.settings.defaultSandboxProfile
-        networkPolicy = sessionService.settings.defaultNetworkPolicy
-        if preset == .quick {
-            folderPath = ""
+    isCheckingRepo = true
+    Task {
+      let isRepo = await sessionService.isGitRepository(path: cleanedFolder)
+      await MainActor.run {
+        guard repoCheckToken == token else { return }
+        isCheckingRepo = false
+        folderIsGitRepo = isRepo
+        if !isRepo {
+          repoBranchMode = .current
+          branchName = ""
+          useExistingWorktree = false
+          existingWorktreePath = ""
+          if sessionService.settings.defaultCreateWorktreeForRepoSessions {
             createWorktree = false
-        } else if preset == .worktree {
+          }
+        } else {
+          if sessionService.settings.defaultCreateWorktreeForRepoSessions {
             createWorktree = true
-            showGitSection = true
+          }
+          prefillBranchIfNeeded()
         }
+      }
     }
+  }
 
-    private func chooseFolder() {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = true
-        panel.canChooseFiles = false
-        panel.allowsMultipleSelection = false
-        panel.canCreateDirectories = false
-        if panel.runModal() == .OK {
-            folderPath = panel.url?.path ?? ""
-            prefillBranchIfNeeded()
-        }
-    }
+  private func createSession() {
+    errorMessage = nil
+    isCreating = true
 
-    private func chooseExistingWorktree() {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = true
-        panel.canChooseFiles = false
-        panel.allowsMultipleSelection = false
-        panel.canCreateDirectories = false
-        if panel.runModal() == .OK {
-            existingWorktreePath = panel.url?.path ?? ""
-        }
-    }
-
-    private func prefillBranchIfNeeded() {
-        guard effectiveCreateWorktree, folderIsGitRepo, !useExistingWorktree else { return }
-        guard branchName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-        let repoName = URL(fileURLWithPath: folderPath).lastPathComponent
-        branchName = BranchNameGenerator.generate(
-            sessionTitle: title.isEmpty ? nil : title,
-            repoName: repoName
+    Task {
+      do {
+        let created = try await sessionService.createSession(
+          from: SessionCreationRequest(
+            title: title,
+            repoPath: folderPath,
+            createWorktree: effectiveCreateWorktree,
+            branchName: resolvedBranchName,
+            existingWorktreePath: useExistingWorktree ? existingWorktreePath : nil,
+            shellPath: shellPath,
+            sandboxProfile: sandboxProfile,
+            networkPolicy: networkPolicy,
+            launchToolID: launchMode == .autoTool ? selectedToolID : nil
+          )
         )
-    }
 
-    private func refreshRepoStatus() {
-        let cleanedFolder = folderPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        let token = UUID()
-        repoCheckToken = token
-
-        guard !cleanedFolder.isEmpty else {
-            isCheckingRepo = false
-            folderIsGitRepo = false
-            repoBranchMode = .current
-            branchName = ""
-            useExistingWorktree = false
-            existingWorktreePath = ""
-            return
-        }
-
-        isCheckingRepo = true
-        Task {
-            let isRepo = await sessionService.isGitRepository(path: cleanedFolder)
-            await MainActor.run {
-                guard repoCheckToken == token else { return }
-                isCheckingRepo = false
-                folderIsGitRepo = isRepo
-                if !isRepo {
-                    repoBranchMode = .current
-                    branchName = ""
-                    useExistingWorktree = false
-                    existingWorktreePath = ""
-                    if sessionService.settings.defaultCreateWorktreeForRepoSessions {
-                        createWorktree = false
-                    }
-                } else {
-                    if sessionService.settings.defaultCreateWorktreeForRepoSessions {
-                        createWorktree = true
-                    }
-                    prefillBranchIfNeeded()
-                }
-            }
-        }
-    }
-
-    private func createSession() {
-        errorMessage = nil
-        isCreating = true
-
-        Task {
+        await MainActor.run {
+          if launchMode == .autoTool {
             do {
-                let created = try await sessionService.createSession(
-                    from: SessionCreationRequest(
-                        title: title,
-                        repoPath: folderPath,
-                        createWorktree: effectiveCreateWorktree,
-                        branchName: resolvedBranchName,
-                        existingWorktreePath: useExistingWorktree ? existingWorktreePath : nil,
-                        shellPath: shellPath,
-                        sandboxProfile: sandboxProfile,
-                        networkPolicy: networkPolicy,
-                        launchToolID: launchMode == .autoTool ? selectedToolID : nil
-                    )
-                )
-
-                await MainActor.run {
-                    if launchMode == .autoTool {
-                        do {
-                            try workflowService.launchTool(selectedToolID, in: created.session.id)
-                        } catch {
-                            sessionService.postStatusMessage(error.localizedDescription, for: created.session.id)
-                        }
-                    }
-                    isCreating = false
-                    coordinator.showingNewSessionSheet = false
-                }
+              try workflowService.launchTool(selectedToolID, in: created.session.id)
             } catch {
-                await MainActor.run {
-                    isCreating = false
-                    errorMessage = error.localizedDescription
-                }
+              sessionService.postStatusMessage(error.localizedDescription, for: created.session.id)
             }
+          }
+          isCreating = false
+          coordinator.showingNewSessionSheet = false
         }
+      } catch {
+        await MainActor.run {
+          isCreating = false
+          errorMessage = error.localizedDescription
+        }
+      }
     }
+  }
 
-    private var resolvedBranchName: String? {
-        let cleaned = branchName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !cleaned.isEmpty else { return nil }
-        if effectiveCreateWorktree { return cleaned }
-        if folderIsGitRepo && repoBranchMode == .custom { return cleaned }
-        return nil
-    }
+  private var resolvedBranchName: String? {
+    let cleaned = branchName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !cleaned.isEmpty else { return nil }
+    if effectiveCreateWorktree { return cleaned }
+    if folderIsGitRepo, repoBranchMode == .custom { return cleaned }
+    return nil
+  }
 }
 
 private enum LaunchMode: Hashable {
-    case plainShell
-    case autoTool
+  case plainShell
+  case autoTool
 }
 
 private enum RepoBranchMode: Hashable {
-    case current
-    case custom
+  case current
+  case custom
 }

--- a/idx0/UI/Sheets/NewSessionSheet.swift
+++ b/idx0/UI/Sheets/NewSessionSheet.swift
@@ -34,6 +34,14 @@ struct NewSessionSheet: View {
         sessionService.settings.appMode.showsVibeFeatures
     }
 
+    private var settingForcesWorktree: Bool {
+        sessionService.settings.defaultCreateWorktreeForRepoSessions && folderIsGitRepo
+    }
+
+    private var effectiveCreateWorktree: Bool {
+        settingForcesWorktree || createWorktree
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             Text("Create Session")
@@ -68,8 +76,15 @@ struct NewSessionSheet: View {
 
                         if showGitSection {
                             Toggle("Create worktree", isOn: $createWorktree)
+                                .disabled(settingForcesWorktree)
 
-                            if createWorktree {
+                            if settingForcesWorktree {
+                                Text("Worktree creation is enforced. Disable it in Settings > Sessions.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            if effectiveCreateWorktree {
                                 if isCheckingRepo {
                                     HStack(spacing: 8) {
                                         ProgressView().controlSize(.small)
@@ -104,7 +119,7 @@ struct NewSessionSheet: View {
                                 }
                             }
 
-                            if !createWorktree, folderIsGitRepo {
+                            if !effectiveCreateWorktree, folderIsGitRepo {
                                 VStack(alignment: .leading, spacing: 6) {
                                     Text("Branch mode")
                                         .font(.caption)
@@ -230,6 +245,9 @@ struct NewSessionSheet: View {
         .onChange(of: folderIsGitRepo) { _, isRepo in
             if isRepo {
                 showGitSection = true
+                if sessionService.settings.defaultCreateWorktreeForRepoSessions {
+                    createWorktree = true
+                }
             }
         }
         .onChange(of: createWorktree) {
@@ -300,13 +318,13 @@ struct NewSessionSheet: View {
         if isCreating || isCheckingRepo {
             return true
         }
-        if createWorktree && !folderIsGitRepo {
+        if effectiveCreateWorktree && !folderIsGitRepo {
             return true
         }
-        if createWorktree && useExistingWorktree && existingWorktreePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if effectiveCreateWorktree && useExistingWorktree && existingWorktreePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return true
         }
-        if !createWorktree &&
+        if !effectiveCreateWorktree &&
             folderIsGitRepo &&
             repoBranchMode == .custom &&
             branchName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -326,8 +344,6 @@ struct NewSessionSheet: View {
         networkPolicy = sessionService.settings.defaultNetworkPolicy
         if preset == .quick {
             folderPath = ""
-            createWorktree = false
-        } else if preset == .repo {
             createWorktree = false
         } else if preset == .worktree {
             createWorktree = true
@@ -359,7 +375,7 @@ struct NewSessionSheet: View {
     }
 
     private func prefillBranchIfNeeded() {
-        guard createWorktree, folderIsGitRepo, !useExistingWorktree else { return }
+        guard effectiveCreateWorktree, folderIsGitRepo, !useExistingWorktree else { return }
         guard branchName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         let repoName = URL(fileURLWithPath: folderPath).lastPathComponent
         branchName = BranchNameGenerator.generate(
@@ -395,7 +411,13 @@ struct NewSessionSheet: View {
                     branchName = ""
                     useExistingWorktree = false
                     existingWorktreePath = ""
+                    if sessionService.settings.defaultCreateWorktreeForRepoSessions {
+                        createWorktree = false
+                    }
                 } else {
+                    if sessionService.settings.defaultCreateWorktreeForRepoSessions {
+                        createWorktree = true
+                    }
                     prefillBranchIfNeeded()
                 }
             }
@@ -412,7 +434,7 @@ struct NewSessionSheet: View {
                     from: SessionCreationRequest(
                         title: title,
                         repoPath: folderPath,
-                        createWorktree: createWorktree,
+                        createWorktree: effectiveCreateWorktree,
                         branchName: resolvedBranchName,
                         existingWorktreePath: useExistingWorktree ? existingWorktreePath : nil,
                         shellPath: shellPath,
@@ -445,7 +467,7 @@ struct NewSessionSheet: View {
     private var resolvedBranchName: String? {
         let cleaned = branchName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else { return nil }
-        if createWorktree { return cleaned }
+        if effectiveCreateWorktree { return cleaned }
         if folderIsGitRepo && repoBranchMode == .custom { return cleaned }
         return nil
     }

--- a/idx0Tests/SessionServiceIntegrationTests.swift
+++ b/idx0Tests/SessionServiceIntegrationTests.swift
@@ -1,403 +1,403 @@
 import Darwin
 import Foundation
-import XCTest
 @testable import idx0
+import XCTest
 
 @MainActor
 final class SessionServiceIntegrationTests: XCTestCase {
-    func testCreateRepoBackedSessionWithoutWorktreeWhenSettingDisabled() async throws {
-        let root = try makeTempRoot(prefix: "idx0-integration-repo")
-        defer { try? FileManager.default.removeItem(at: root) }
+  func testCreateRepoBackedSessionWithoutWorktreeWhenSettingDisabled() async throws {
+    let root = try makeTempRoot(prefix: "idx0-integration-repo")
+    defer { try? FileManager.default.removeItem(at: root) }
 
-        let repo = try makeGitRepo(root: root, name: "repo")
-        let branch = try currentBranch(at: repo.path)
-        let service = try makeService(root: root)
-        service.saveSettings { $0.defaultCreateWorktreeForRepoSessions = false }
+    let repo = try makeGitRepo(root: root, name: "repo")
+    let branch = try currentBranch(at: repo.path)
+    let service = try makeService(root: root)
+    service.saveSettings { $0.defaultCreateWorktreeForRepoSessions = false }
 
-        let result = try await service.createSession(from: SessionCreationRequest(
-            title: "Repo Session",
-            repoPath: repo.path,
-            createWorktree: false,
-            branchName: nil,
-            existingWorktreePath: nil,
-            shellPath: nil
-        ))
+    let result = try await service.createSession(from: SessionCreationRequest(
+      title: "Repo Session",
+      repoPath: repo.path,
+      createWorktree: false,
+      branchName: nil,
+      existingWorktreePath: nil,
+      shellPath: nil
+    ))
 
-        XCTAssertNil(result.worktree)
-        XCTAssertEqual(canonicalPath(result.session.repoPath), canonicalPath(repo.path))
-        XCTAssertEqual(result.session.branchName, branch)
-        XCTAssertFalse(result.session.isWorktreeBacked)
-        XCTAssertNil(result.session.worktreePath)
+    XCTAssertNil(result.worktree)
+    XCTAssertEqual(canonicalPath(result.session.repoPath), canonicalPath(repo.path))
+    XCTAssertEqual(result.session.branchName, branch)
+    XCTAssertFalse(result.session.isWorktreeBacked)
+    XCTAssertNil(result.session.worktreePath)
 
-        try await Task.sleep(nanoseconds: 300_000_000)
+    try await Task.sleep(nanoseconds: 300_000_000)
+  }
+
+  func testCreateRepoBackedSessionCreatesWorktreeByDefaultWhenSettingEnabled() async throws {
+    let root = try makeTempRoot(prefix: "idx0-integration-repo-default-worktree")
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let repo = try makeGitRepo(root: root, name: "repo")
+    let service = try makeService(root: root)
+    service.saveSettings { $0.defaultCreateWorktreeForRepoSessions = true }
+
+    let result = try await service.createSession(from: SessionCreationRequest(
+      title: "Repo Session",
+      repoPath: repo.path,
+      createWorktree: false,
+      branchName: nil,
+      existingWorktreePath: nil,
+      shellPath: nil
+    ))
+
+    XCTAssertTrue(result.session.isWorktreeBacked)
+    XCTAssertNotNil(result.session.worktreePath)
+    XCTAssertNotNil(result.worktree)
+    if let worktreePath = result.session.worktreePath {
+      XCTAssertTrue(worktreePath.hasPrefix(repo.path + "/.idx0/worktrees/"))
+    }
+  }
+
+  func testCreateWorktreeBackedSessionFromGitRepo() async throws {
+    let root = try makeTempRoot(prefix: "idx0-integration-worktree")
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let repo = try makeGitRepo(root: root, name: "repo")
+    let service = try makeService(root: root)
+    let branch = "idx0/integration-\(UUID().uuidString.prefix(8))"
+
+    let result = try await service.createSession(from: SessionCreationRequest(
+      title: "Worktree Session",
+      repoPath: repo.path,
+      createWorktree: true,
+      branchName: branch,
+      existingWorktreePath: nil,
+      shellPath: nil
+    ))
+
+    guard let worktreePath = result.session.worktreePath else {
+      XCTFail("Expected worktree path")
+      return
     }
 
-    func testCreateRepoBackedSessionCreatesWorktreeByDefaultWhenSettingEnabled() async throws {
-        let root = try makeTempRoot(prefix: "idx0-integration-repo-default-worktree")
-        defer { try? FileManager.default.removeItem(at: root) }
+    XCTAssertTrue(result.session.isWorktreeBacked)
+    XCTAssertEqual(result.session.branchName, branch)
+    XCTAssertEqual(result.worktree?.branchName, branch)
+    XCTAssertEqual(result.worktree?.worktreePath, worktreePath)
+    XCTAssertTrue(worktreePath.hasPrefix(repo.path + "/.idx0/worktrees/"))
 
-        let repo = try makeGitRepo(root: root, name: "repo")
-        let service = try makeService(root: root)
-        service.saveSettings { $0.defaultCreateWorktreeForRepoSessions = true }
+    let worktreeName = URL(fileURLWithPath: worktreePath).lastPathComponent
+    let pattern = #"^wt-[a-z0-9]{12}(?:-[0-9]+)?$"#
+    let regex = try NSRegularExpression(pattern: pattern)
+    let range = NSRange(location: 0, length: worktreeName.utf16.count)
+    XCTAssertNotNil(regex.firstMatch(in: worktreeName, options: [], range: range))
 
-        let result = try await service.createSession(from: SessionCreationRequest(
-            title: "Repo Session",
-            repoPath: repo.path,
-            createWorktree: false,
-            branchName: nil,
-            existingWorktreePath: nil,
-            shellPath: nil
-        ))
+    var isDirectory: ObjCBool = false
+    XCTAssertTrue(FileManager.default.fileExists(atPath: worktreePath, isDirectory: &isDirectory))
+    XCTAssertTrue(isDirectory.boolValue)
 
-        XCTAssertTrue(result.session.isWorktreeBacked)
-        XCTAssertNotNil(result.session.worktreePath)
-        XCTAssertNotNil(result.worktree)
-        if let worktreePath = result.session.worktreePath {
-            XCTAssertTrue(worktreePath.hasPrefix(repo.path + "/.idx0/worktrees/"))
-        }
+    let worktreeList = try runGit(["worktree", "list", "--porcelain"], currentDirectory: repo.path)
+    XCTAssertTrue(worktreeList.contains(worktreePath))
+    let status = try runGit(["status", "--short"], currentDirectory: repo.path)
+    XCTAssertFalse(status.contains(".idx0/"))
+    XCTAssertTrue(status.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+    try await Task.sleep(nanoseconds: 300_000_000)
+  }
+
+  func testAttachExistingWorktreeSessionFromGitRepo() async throws {
+    let root = try makeTempRoot(prefix: "idx0-integration-attach-worktree")
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let repo = try makeGitRepo(root: root, name: "repo")
+    let service = try makeService(root: root)
+    let branch = "idx0/attach-\(UUID().uuidString.prefix(8))"
+    let existingWorktreePath = root
+      .appendingPathComponent("attached-\(UUID().uuidString.prefix(8))", isDirectory: true)
+      .path
+
+    _ = try runGit(
+      ["worktree", "add", existingWorktreePath, "-b", branch],
+      currentDirectory: repo.path
+    )
+
+    let result = try await service.createSession(from: SessionCreationRequest(
+      title: "Attach Existing",
+      repoPath: repo.path,
+      createWorktree: true,
+      branchName: nil,
+      existingWorktreePath: existingWorktreePath,
+      shellPath: nil
+    ))
+
+    XCTAssertTrue(result.session.isWorktreeBacked)
+    XCTAssertEqual(canonicalPath(result.session.repoPath), canonicalPath(repo.path))
+    XCTAssertEqual(canonicalPath(result.session.worktreePath), canonicalPath(existingWorktreePath))
+    XCTAssertEqual(result.session.branchName, branch)
+    XCTAssertEqual(canonicalPath(result.worktree?.worktreePath), canonicalPath(existingWorktreePath))
+  }
+
+  func testRestoresPersistedSessionsAndSelection() async throws {
+    let root = try makeTempRoot(prefix: "idx0-integration-restore")
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let service = try makeService(root: root)
+
+    let first = try await service.createSession(from: SessionCreationRequest(
+      title: "First",
+      repoPath: nil,
+      createWorktree: false,
+      branchName: nil,
+      existingWorktreePath: nil,
+      shellPath: nil
+    )).session
+
+    _ = try await service.createSession(from: SessionCreationRequest(
+      title: "Second",
+      repoPath: nil,
+      createWorktree: false,
+      branchName: nil,
+      existingWorktreePath: nil,
+      shellPath: nil
+    )).session
+
+    service.selectSession(first.id)
+
+    // Session writes are debounced in SessionService.
+    try await Task.sleep(nanoseconds: 500_000_000)
+
+    let restored = try makeService(root: root)
+    XCTAssertEqual(restored.sessions.count, 2)
+    XCTAssertEqual(restored.selectedSessionID, first.id)
+  }
+
+  func testInboxItemCreationAndResolution() async throws {
+    let root = try makeTempRoot(prefix: "idx0-integration-inbox")
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let service = try makeService(root: root)
+    let first = try await service.createSession(from: SessionCreationRequest(title: "First")).session
+    _ = try await service.createSession(from: SessionCreationRequest(title: "Second")).session
+
+    service.injectAttention(sessionID: first.id, reason: .needsInput, message: "Review needed")
+    XCTAssertEqual(service.unresolvedAttentionItems.count, 1)
+    XCTAssertEqual(service.unresolvedAttentionItems.first?.sessionID, first.id)
+
+    service.selectSession(first.id)
+    XCTAssertTrue(service.unresolvedAttentionItems.isEmpty)
+  }
+
+  func testBrowserPaneStateReloadAndControllerCreation() async throws {
+    let root = try makeTempRoot(prefix: "idx0-integration-browser")
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let service = try makeService(root: root)
+    let session = try await service.createSession(from: SessionCreationRequest(title: "Browser")).session
+    service.toggleBrowserSplit(for: session.id)
+    service.setBrowserURL(for: session.id, urlString: "https://example.com")
+
+    try await Task.sleep(nanoseconds: 500_000_000)
+
+    let restored = try makeService(root: root)
+    let restoredSession = restored.sessions.first(where: { $0.id == session.id })
+    XCTAssertEqual(restoredSession?.browserState?.isVisible, true)
+    XCTAssertEqual(URL(string: restoredSession?.browserState?.currentURL ?? "")?.host, "example.com")
+    XCTAssertNotNil(restored.controller(for: session.id))
+    XCTAssertNotNil(restored.browserController(for: session.id))
+  }
+
+  func testIPCServerRequestResponseRoundTrip() throws {
+    let socketPath = shortSocketPath()
+    defer { unlink(socketPath) }
+
+    let server = IPCServer(socketPath: socketPath) { request in
+      IPCResponse(
+        success: request.command == "ping",
+        message: request.command == "ping" ? "pong" : "bad command",
+        data: ["echo": request.payload["value"] ?? ""]
+      )
+    }
+    server.start()
+    defer { server.stop() }
+
+    waitForSocket(path: socketPath, timeout: 2.0)
+
+    let response = try sendIPCRequest(
+      socketPath: socketPath,
+      request: IPCRequest(command: "ping", payload: ["value": "hello"])
+    )
+    XCTAssertTrue(response.success)
+    XCTAssertEqual(response.message, "pong")
+    XCTAssertEqual(response.data?["echo"], "hello")
+  }
+
+  private func shortSocketPath() -> String {
+    let suffix = UUID().uuidString.prefix(8)
+    return "/tmp/idx0-\(suffix).sock"
+  }
+
+  private func makeService(root: URL) throws -> SessionService {
+    let paths = try makePaths(root: root)
+    let gitService = GitService()
+    let worktreeService = WorktreeService(gitService: gitService, paths: paths)
+    return SessionService(
+      sessionStore: SessionStore(url: paths.sessionsFile),
+      projectStore: ProjectStore(url: paths.projectsFile),
+      inboxStore: InboxStore(url: paths.inboxFile),
+      settingsStore: SettingsStore(url: paths.settingsFile),
+      worktreeService: worktreeService,
+      host: .shared
+    )
+  }
+
+  private func makePaths(root: URL) throws -> FileSystemPaths {
+    let appSupport = root.appendingPathComponent("AppSupport", isDirectory: true)
+    let paths = FileSystemPaths(
+      appSupportDirectory: appSupport,
+      sessionsFile: appSupport.appendingPathComponent("sessions.json"),
+      projectsFile: appSupport.appendingPathComponent("projects.json"),
+      inboxFile: appSupport.appendingPathComponent("inbox.json"),
+      settingsFile: appSupport.appendingPathComponent("settings.json"),
+      runDirectory: appSupport.appendingPathComponent("run", isDirectory: true),
+      tempDirectory: appSupport.appendingPathComponent("temp", isDirectory: true),
+      worktreesDirectory: appSupport.appendingPathComponent("worktrees", isDirectory: true)
+    )
+    try paths.ensureDirectories()
+    return paths
+  }
+
+  private func makeTempRoot(prefix: String) throws -> URL {
+    let root = FileManager.default.temporaryDirectory
+      .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root
+  }
+
+  private func waitForSocket(path: String, timeout: TimeInterval) {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+      if FileManager.default.fileExists(atPath: path) {
+        return
+      }
+      Thread.sleep(forTimeInterval: 0.02)
+    }
+    XCTFail("Socket was not created in time: \(path)")
+  }
+
+  private func sendIPCRequest(socketPath: String, request: IPCRequest) throws -> IPCResponse {
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard fd >= 0 else {
+      throw NSError(domain: "IPC", code: 1, userInfo: [NSLocalizedDescriptionKey: "socket() failed"])
+    }
+    defer { close(fd) }
+
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    let bytes = Array(socketPath.utf8)
+    let maxPathLength = MemoryLayout.size(ofValue: addr.sun_path)
+    guard bytes.count < maxPathLength else {
+      throw NSError(domain: "IPC", code: 2, userInfo: [NSLocalizedDescriptionKey: "Socket path too long"])
     }
 
-    func testCreateWorktreeBackedSessionFromGitRepo() async throws {
-        let root = try makeTempRoot(prefix: "idx0-integration-worktree")
-        defer { try? FileManager.default.removeItem(at: root) }
-
-        let repo = try makeGitRepo(root: root, name: "repo")
-        let service = try makeService(root: root)
-        let branch = "idx0/integration-\(UUID().uuidString.prefix(8))"
-
-        let result = try await service.createSession(from: SessionCreationRequest(
-            title: "Worktree Session",
-            repoPath: repo.path,
-            createWorktree: true,
-            branchName: branch,
-            existingWorktreePath: nil,
-            shellPath: nil
-        ))
-
-        guard let worktreePath = result.session.worktreePath else {
-            XCTFail("Expected worktree path")
-            return
-        }
-
-        XCTAssertTrue(result.session.isWorktreeBacked)
-        XCTAssertEqual(result.session.branchName, branch)
-        XCTAssertEqual(result.worktree?.branchName, branch)
-        XCTAssertEqual(result.worktree?.worktreePath, worktreePath)
-        XCTAssertTrue(worktreePath.hasPrefix(repo.path + "/.idx0/worktrees/"))
-
-        let worktreeName = URL(fileURLWithPath: worktreePath).lastPathComponent
-        let pattern = #"^wt-[a-z0-9]{12}(?:-[0-9]+)?$"#
-        let regex = try NSRegularExpression(pattern: pattern)
-        let range = NSRange(location: 0, length: worktreeName.utf16.count)
-        XCTAssertNotNil(regex.firstMatch(in: worktreeName, options: [], range: range))
-
-        var isDirectory: ObjCBool = false
-        XCTAssertTrue(FileManager.default.fileExists(atPath: worktreePath, isDirectory: &isDirectory))
-        XCTAssertTrue(isDirectory.boolValue)
-
-        let worktreeList = try runGit(["worktree", "list", "--porcelain"], currentDirectory: repo.path)
-        XCTAssertTrue(worktreeList.contains(worktreePath))
-        let status = try runGit(["status", "--short"], currentDirectory: repo.path)
-        XCTAssertFalse(status.contains(".idx0/"))
-        XCTAssertTrue(status.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-
-        try await Task.sleep(nanoseconds: 300_000_000)
+    withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+      let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
+      raw.initialize(repeating: 0, count: maxPathLength)
+      for index in bytes.indices {
+        raw[index] = CChar(bitPattern: bytes[index])
+      }
     }
 
-    func testAttachExistingWorktreeSessionFromGitRepo() async throws {
-        let root = try makeTempRoot(prefix: "idx0-integration-attach-worktree")
-        defer { try? FileManager.default.removeItem(at: root) }
-
-        let repo = try makeGitRepo(root: root, name: "repo")
-        let service = try makeService(root: root)
-        let branch = "idx0/attach-\(UUID().uuidString.prefix(8))"
-        let existingWorktreePath = root
-            .appendingPathComponent("attached-\(UUID().uuidString.prefix(8))", isDirectory: true)
-            .path
-
-        _ = try runGit(
-            ["worktree", "add", existingWorktreePath, "-b", branch],
-            currentDirectory: repo.path
-        )
-
-        let result = try await service.createSession(from: SessionCreationRequest(
-            title: "Attach Existing",
-            repoPath: repo.path,
-            createWorktree: true,
-            branchName: nil,
-            existingWorktreePath: existingWorktreePath,
-            shellPath: nil
-        ))
-
-        XCTAssertTrue(result.session.isWorktreeBacked)
-        XCTAssertEqual(canonicalPath(result.session.repoPath), canonicalPath(repo.path))
-        XCTAssertEqual(canonicalPath(result.session.worktreePath), canonicalPath(existingWorktreePath))
-        XCTAssertEqual(result.session.branchName, branch)
-        XCTAssertEqual(canonicalPath(result.worktree?.worktreePath), canonicalPath(existingWorktreePath))
+    let len = socklen_t(MemoryLayout<sa_family_t>.size + bytes.count + 1)
+    let connectResult = withUnsafePointer(to: &addr) {
+      $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+        connect(fd, $0, len)
+      }
+    }
+    guard connectResult == 0 else {
+      throw NSError(domain: "IPC", code: 3, userInfo: [NSLocalizedDescriptionKey: "connect() failed"])
     }
 
-    func testRestoresPersistedSessionsAndSelection() async throws {
-        let root = try makeTempRoot(prefix: "idx0-integration-restore")
-        defer { try? FileManager.default.removeItem(at: root) }
+    let requestData = try JSONEncoder().encode(request)
+    _ = requestData.withUnsafeBytes { bytes in
+      write(fd, bytes.baseAddress, bytes.count)
+    }
+    shutdown(fd, SHUT_WR)
 
-        let service = try makeService(root: root)
-
-        let first = try await service.createSession(from: SessionCreationRequest(
-            title: "First",
-            repoPath: nil,
-            createWorktree: false,
-            branchName: nil,
-            existingWorktreePath: nil,
-            shellPath: nil
-        )).session
-
-        _ = try await service.createSession(from: SessionCreationRequest(
-            title: "Second",
-            repoPath: nil,
-            createWorktree: false,
-            branchName: nil,
-            existingWorktreePath: nil,
-            shellPath: nil
-        )).session
-
-        service.selectSession(first.id)
-
-        // Session writes are debounced in SessionService.
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        let restored = try makeService(root: root)
-        XCTAssertEqual(restored.sessions.count, 2)
-        XCTAssertEqual(restored.selectedSessionID, first.id)
+    var responseData = Data()
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    while true {
+      let count = read(fd, &buffer, buffer.count)
+      if count > 0 {
+        responseData.append(contentsOf: buffer.prefix(Int(count)))
+      } else {
+        break
+      }
     }
 
-    func testInboxItemCreationAndResolution() async throws {
-        let root = try makeTempRoot(prefix: "idx0-integration-inbox")
-        defer { try? FileManager.default.removeItem(at: root) }
+    return try JSONDecoder().decode(IPCResponse.self, from: responseData)
+  }
 
-        let service = try makeService(root: root)
-        let first = try await service.createSession(from: SessionCreationRequest(title: "First")).session
-        _ = try await service.createSession(from: SessionCreationRequest(title: "Second")).session
+  private func makeGitRepo(root: URL, name: String) throws -> URL {
+    let repo = root.appendingPathComponent(name, isDirectory: true)
+    try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
 
-        service.injectAttention(sessionID: first.id, reason: .needsInput, message: "Review needed")
-        XCTAssertEqual(service.unresolvedAttentionItems.count, 1)
-        XCTAssertEqual(service.unresolvedAttentionItems.first?.sessionID, first.id)
+    _ = try runGit(["init", "-q"], currentDirectory: repo.path)
+    _ = try runGit(["config", "user.email", "idx0-tests@example.com"], currentDirectory: repo.path)
+    _ = try runGit(["config", "user.name", "idx0 tests"], currentDirectory: repo.path)
 
-        service.selectSession(first.id)
-        XCTAssertTrue(service.unresolvedAttentionItems.isEmpty)
+    let readme = repo.appendingPathComponent("README.md")
+    try "integration test\n".data(using: .utf8)?.write(to: readme)
+
+    _ = try runGit(["add", "README.md"], currentDirectory: repo.path)
+    _ = try runGit(["commit", "-q", "-m", "initial"], currentDirectory: repo.path)
+    return repo
+  }
+
+  private func currentBranch(at repoPath: String) throws -> String? {
+    let branch = try runGit(["branch", "--show-current"], currentDirectory: repoPath)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    return branch.isEmpty ? nil : branch
+  }
+
+  private func canonicalPath(_ path: String?) -> String? {
+    guard let path else { return nil }
+    return URL(fileURLWithPath: path)
+      .resolvingSymlinksInPath()
+      .standardizedFileURL
+      .path
+  }
+
+  @discardableResult
+  private func runGit(_ arguments: [String], currentDirectory: String) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = arguments
+    process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory)
+
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try process.run()
+    process.waitUntilExit()
+
+    let stdoutString = String(
+      data: stdout.fileHandleForReading.readDataToEndOfFile(),
+      encoding: .utf8
+    ) ?? ""
+    let stderrString = String(
+      data: stderr.fileHandleForReading.readDataToEndOfFile(),
+      encoding: .utf8
+    ) ?? ""
+
+    guard process.terminationStatus == 0 else {
+      throw NSError(
+        domain: "SessionServiceIntegrationTests",
+        code: Int(process.terminationStatus),
+        userInfo: [NSLocalizedDescriptionKey: stderrString.isEmpty ? stdoutString : stderrString]
+      )
     }
 
-    func testBrowserPaneStateReloadAndControllerCreation() async throws {
-        let root = try makeTempRoot(prefix: "idx0-integration-browser")
-        defer { try? FileManager.default.removeItem(at: root) }
-
-        let service = try makeService(root: root)
-        let session = try await service.createSession(from: SessionCreationRequest(title: "Browser")).session
-        service.toggleBrowserSplit(for: session.id)
-        service.setBrowserURL(for: session.id, urlString: "https://example.com")
-
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        let restored = try makeService(root: root)
-        let restoredSession = restored.sessions.first(where: { $0.id == session.id })
-        XCTAssertEqual(restoredSession?.browserState?.isVisible, true)
-        XCTAssertEqual(URL(string: restoredSession?.browserState?.currentURL ?? "")?.host, "example.com")
-        XCTAssertNotNil(restored.controller(for: session.id))
-        XCTAssertNotNil(restored.browserController(for: session.id))
-    }
-
-    func testIPCServerRequestResponseRoundTrip() throws {
-        let socketPath = shortSocketPath()
-        defer { unlink(socketPath) }
-
-        let server = IPCServer(socketPath: socketPath) { request in
-            IPCResponse(
-                success: request.command == "ping",
-                message: request.command == "ping" ? "pong" : "bad command",
-                data: ["echo": request.payload["value"] ?? ""]
-            )
-        }
-        server.start()
-        defer { server.stop() }
-
-        waitForSocket(path: socketPath, timeout: 2.0)
-
-        let response = try sendIPCRequest(
-            socketPath: socketPath,
-            request: IPCRequest(command: "ping", payload: ["value": "hello"])
-        )
-        XCTAssertTrue(response.success)
-        XCTAssertEqual(response.message, "pong")
-        XCTAssertEqual(response.data?["echo"], "hello")
-    }
-
-    private func shortSocketPath() -> String {
-        let suffix = UUID().uuidString.prefix(8)
-        return "/tmp/idx0-\(suffix).sock"
-    }
-
-    private func makeService(root: URL) throws -> SessionService {
-        let paths = try makePaths(root: root)
-        let gitService = GitService()
-        let worktreeService = WorktreeService(gitService: gitService, paths: paths)
-        return SessionService(
-            sessionStore: SessionStore(url: paths.sessionsFile),
-            projectStore: ProjectStore(url: paths.projectsFile),
-            inboxStore: InboxStore(url: paths.inboxFile),
-            settingsStore: SettingsStore(url: paths.settingsFile),
-            worktreeService: worktreeService,
-            host: .shared
-        )
-    }
-
-    private func makePaths(root: URL) throws -> FileSystemPaths {
-        let appSupport = root.appendingPathComponent("AppSupport", isDirectory: true)
-        let paths = FileSystemPaths(
-            appSupportDirectory: appSupport,
-            sessionsFile: appSupport.appendingPathComponent("sessions.json"),
-            projectsFile: appSupport.appendingPathComponent("projects.json"),
-            inboxFile: appSupport.appendingPathComponent("inbox.json"),
-            settingsFile: appSupport.appendingPathComponent("settings.json"),
-            runDirectory: appSupport.appendingPathComponent("run", isDirectory: true),
-            tempDirectory: appSupport.appendingPathComponent("temp", isDirectory: true),
-            worktreesDirectory: appSupport.appendingPathComponent("worktrees", isDirectory: true)
-        )
-        try paths.ensureDirectories()
-        return paths
-    }
-
-    private func makeTempRoot(prefix: String) throws -> URL {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        return root
-    }
-
-    private func waitForSocket(path: String, timeout: TimeInterval) {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if FileManager.default.fileExists(atPath: path) {
-                return
-            }
-            Thread.sleep(forTimeInterval: 0.02)
-        }
-        XCTFail("Socket was not created in time: \(path)")
-    }
-
-    private func sendIPCRequest(socketPath: String, request: IPCRequest) throws -> IPCResponse {
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        guard fd >= 0 else {
-            throw NSError(domain: "IPC", code: 1, userInfo: [NSLocalizedDescriptionKey: "socket() failed"])
-        }
-        defer { close(fd) }
-
-        var addr = sockaddr_un()
-        addr.sun_family = sa_family_t(AF_UNIX)
-        let bytes = Array(socketPath.utf8)
-        let maxPathLength = MemoryLayout.size(ofValue: addr.sun_path)
-        guard bytes.count < maxPathLength else {
-            throw NSError(domain: "IPC", code: 2, userInfo: [NSLocalizedDescriptionKey: "Socket path too long"])
-        }
-
-        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
-            let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
-            raw.initialize(repeating: 0, count: maxPathLength)
-            for index in bytes.indices {
-                raw[index] = CChar(bitPattern: bytes[index])
-            }
-        }
-
-        let len = socklen_t(MemoryLayout<sa_family_t>.size + bytes.count + 1)
-        let connectResult = withUnsafePointer(to: &addr) {
-            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                connect(fd, $0, len)
-            }
-        }
-        guard connectResult == 0 else {
-            throw NSError(domain: "IPC", code: 3, userInfo: [NSLocalizedDescriptionKey: "connect() failed"])
-        }
-
-        let requestData = try JSONEncoder().encode(request)
-        _ = requestData.withUnsafeBytes { bytes in
-            write(fd, bytes.baseAddress, bytes.count)
-        }
-        shutdown(fd, SHUT_WR)
-
-        var responseData = Data()
-        var buffer = [UInt8](repeating: 0, count: 4096)
-        while true {
-            let count = read(fd, &buffer, buffer.count)
-            if count > 0 {
-                responseData.append(contentsOf: buffer.prefix(Int(count)))
-            } else {
-                break
-            }
-        }
-
-        return try JSONDecoder().decode(IPCResponse.self, from: responseData)
-    }
-
-    private func makeGitRepo(root: URL, name: String) throws -> URL {
-        let repo = root.appendingPathComponent(name, isDirectory: true)
-        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
-
-        _ = try runGit(["init", "-q"], currentDirectory: repo.path)
-        _ = try runGit(["config", "user.email", "idx0-tests@example.com"], currentDirectory: repo.path)
-        _ = try runGit(["config", "user.name", "idx0 tests"], currentDirectory: repo.path)
-
-        let readme = repo.appendingPathComponent("README.md")
-        try "integration test\n".data(using: .utf8)?.write(to: readme)
-
-        _ = try runGit(["add", "README.md"], currentDirectory: repo.path)
-        _ = try runGit(["commit", "-q", "-m", "initial"], currentDirectory: repo.path)
-        return repo
-    }
-
-    private func currentBranch(at repoPath: String) throws -> String? {
-        let branch = try runGit(["branch", "--show-current"], currentDirectory: repoPath)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return branch.isEmpty ? nil : branch
-    }
-
-    private func canonicalPath(_ path: String?) -> String? {
-        guard let path else { return nil }
-        return URL(fileURLWithPath: path)
-            .resolvingSymlinksInPath()
-            .standardizedFileURL
-            .path
-    }
-
-    @discardableResult
-    private func runGit(_ arguments: [String], currentDirectory: String) throws -> String {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-        process.arguments = arguments
-        process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory)
-
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardOutput = stdout
-        process.standardError = stderr
-
-        try process.run()
-        process.waitUntilExit()
-
-        let stdoutString = String(
-            data: stdout.fileHandleForReading.readDataToEndOfFile(),
-            encoding: .utf8
-        ) ?? ""
-        let stderrString = String(
-            data: stderr.fileHandleForReading.readDataToEndOfFile(),
-            encoding: .utf8
-        ) ?? ""
-
-        guard process.terminationStatus == 0 else {
-            throw NSError(
-                domain: "SessionServiceIntegrationTests",
-                code: Int(process.terminationStatus),
-                userInfo: [NSLocalizedDescriptionKey: stderrString.isEmpty ? stdoutString : stderrString]
-            )
-        }
-
-        return stdoutString
-    }
+    return stdoutString
+  }
 }

--- a/idx0Tests/SessionServiceIntegrationTests.swift
+++ b/idx0Tests/SessionServiceIntegrationTests.swift
@@ -5,13 +5,14 @@ import XCTest
 
 @MainActor
 final class SessionServiceIntegrationTests: XCTestCase {
-    func testCreateRepoBackedSessionFromGitRepo() async throws {
+    func testCreateRepoBackedSessionWithoutWorktreeWhenSettingDisabled() async throws {
         let root = try makeTempRoot(prefix: "idx0-integration-repo")
         defer { try? FileManager.default.removeItem(at: root) }
 
         let repo = try makeGitRepo(root: root, name: "repo")
         let branch = try currentBranch(at: repo.path)
         let service = try makeService(root: root)
+        service.saveSettings { $0.defaultCreateWorktreeForRepoSessions = false }
 
         let result = try await service.createSession(from: SessionCreationRequest(
             title: "Repo Session",
@@ -29,6 +30,31 @@ final class SessionServiceIntegrationTests: XCTestCase {
         XCTAssertNil(result.session.worktreePath)
 
         try await Task.sleep(nanoseconds: 300_000_000)
+    }
+
+    func testCreateRepoBackedSessionCreatesWorktreeByDefaultWhenSettingEnabled() async throws {
+        let root = try makeTempRoot(prefix: "idx0-integration-repo-default-worktree")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let repo = try makeGitRepo(root: root, name: "repo")
+        let service = try makeService(root: root)
+        service.saveSettings { $0.defaultCreateWorktreeForRepoSessions = true }
+
+        let result = try await service.createSession(from: SessionCreationRequest(
+            title: "Repo Session",
+            repoPath: repo.path,
+            createWorktree: false,
+            branchName: nil,
+            existingWorktreePath: nil,
+            shellPath: nil
+        ))
+
+        XCTAssertTrue(result.session.isWorktreeBacked)
+        XCTAssertNotNil(result.session.worktreePath)
+        XCTAssertNotNil(result.worktree)
+        if let worktreePath = result.session.worktreePath {
+            XCTAssertTrue(worktreePath.hasPrefix(repo.path + "/.idx0/worktrees/"))
+        }
     }
 
     func testCreateWorktreeBackedSessionFromGitRepo() async throws {
@@ -57,6 +83,13 @@ final class SessionServiceIntegrationTests: XCTestCase {
         XCTAssertEqual(result.session.branchName, branch)
         XCTAssertEqual(result.worktree?.branchName, branch)
         XCTAssertEqual(result.worktree?.worktreePath, worktreePath)
+        XCTAssertTrue(worktreePath.hasPrefix(repo.path + "/.idx0/worktrees/"))
+
+        let worktreeName = URL(fileURLWithPath: worktreePath).lastPathComponent
+        let pattern = #"^wt-[a-z0-9]{12}(?:-[0-9]+)?$"#
+        let regex = try NSRegularExpression(pattern: pattern)
+        let range = NSRange(location: 0, length: worktreeName.utf16.count)
+        XCTAssertNotNil(regex.firstMatch(in: worktreeName, options: [], range: range))
 
         var isDirectory: ObjCBool = false
         XCTAssertTrue(FileManager.default.fileExists(atPath: worktreePath, isDirectory: &isDirectory))
@@ -64,6 +97,9 @@ final class SessionServiceIntegrationTests: XCTestCase {
 
         let worktreeList = try runGit(["worktree", "list", "--porcelain"], currentDirectory: repo.path)
         XCTAssertTrue(worktreeList.contains(worktreePath))
+        let status = try runGit(["status", "--short"], currentDirectory: repo.path)
+        XCTAssertFalse(status.contains(".idx0/"))
+        XCTAssertTrue(status.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
 
         try await Task.sleep(nanoseconds: 300_000_000)
     }

--- a/idx0Tests/WorktreePathGenerationTests.swift
+++ b/idx0Tests/WorktreePathGenerationTests.swift
@@ -1,255 +1,255 @@
 import Foundation
-import XCTest
 @testable import idx0
+import XCTest
 
 final class WorktreePathGenerationTests: XCTestCase {
-    func testCreateWorktreeUsesWorkspaceLocalPathAndAppendsCollisionSuffix() async throws {
-        let temp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("idx0-worktree-tests-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: temp) }
+  func testCreateWorktreeUsesWorkspaceLocalPathAndAppendsCollisionSuffix() async throws {
+    let temp = FileManager.default.temporaryDirectory
+      .appendingPathComponent("idx0-worktree-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: temp) }
 
-        let paths = try makePaths(root: temp)
-        let repoRoot = try makeRepoRoot(at: temp, name: "repo")
-        let git = MockGitService()
-        let service = WorktreeService(
-            gitService: git,
-            paths: paths,
-            worktreeNameGenerator: { "collision-name" }
-        )
+    let paths = try makePaths(root: temp)
+    let repoRoot = try makeRepoRoot(at: temp, name: "repo")
+    let git = MockGitService()
+    let service = WorktreeService(
+      gitService: git,
+      paths: paths,
+      worktreeNameGenerator: { "collision-name" }
+    )
 
-        let first = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/fix", sessionTitle: "Fix")
+    let first = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/fix", sessionTitle: "Fix")
 
-        try FileManager.default.createDirectory(atPath: first.worktreePath, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(atPath: first.worktreePath, withIntermediateDirectories: true)
 
-        let second = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/fix-2", sessionTitle: "Fix")
+    let second = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/fix-2", sessionTitle: "Fix")
 
-        let createdPaths = git.createdWorktreePaths
-        XCTAssertEqual(createdPaths.count, 2)
-        XCTAssertEqual(URL(fileURLWithPath: first.worktreePath).lastPathComponent, "wt-collisionnam")
-        XCTAssertEqual(URL(fileURLWithPath: second.worktreePath).lastPathComponent, "wt-collisionnam-2")
+    let createdPaths = git.createdWorktreePaths
+    XCTAssertEqual(createdPaths.count, 2)
+    XCTAssertEqual(URL(fileURLWithPath: first.worktreePath).lastPathComponent, "wt-collisionnam")
+    XCTAssertEqual(URL(fileURLWithPath: second.worktreePath).lastPathComponent, "wt-collisionnam-2")
 
-        let expectedPrefix = repoRoot
-            .appendingPathComponent(".idx0/worktrees", isDirectory: true)
-            .path + "/"
-        XCTAssertTrue(first.worktreePath.hasPrefix(expectedPrefix))
-        XCTAssertTrue(second.worktreePath.hasPrefix(expectedPrefix))
+    let expectedPrefix = repoRoot
+      .appendingPathComponent(".idx0/worktrees", isDirectory: true)
+      .path + "/"
+    XCTAssertTrue(first.worktreePath.hasPrefix(expectedPrefix))
+    XCTAssertTrue(second.worktreePath.hasPrefix(expectedPrefix))
+  }
+
+  func testCreateWorktreeAddsIDX0RuleToLocalExcludeIdempotently() async throws {
+    let temp = FileManager.default.temporaryDirectory
+      .appendingPathComponent("idx0-worktree-exclude-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: temp) }
+
+    let paths = try makePaths(root: temp)
+    let repoRoot = try makeRepoRoot(at: temp, name: "repo")
+    let excludeURL = repoRoot.appendingPathComponent(".git/info/exclude", isDirectory: false)
+    try "existing-rule\n".write(to: excludeURL, atomically: true, encoding: .utf8)
+
+    let git = MockGitService()
+    let service = WorktreeService(
+      gitService: git,
+      paths: paths,
+      worktreeNameGenerator: { "idempotent" }
+    )
+
+    _ = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/one", sessionTitle: "One")
+    _ = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/two", sessionTitle: "Two")
+
+    let exclude = try String(contentsOf: excludeURL, encoding: .utf8)
+    let normalizedLines = exclude
+      .components(separatedBy: .newlines)
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+    XCTAssertEqual(normalizedLines.count(where: { $0 == ".idx0/" }), 1)
+  }
+
+  func testCreateWorktreeUpdatesExcludeWhenDotGitIsFile() async throws {
+    let temp = FileManager.default.temporaryDirectory
+      .appendingPathComponent("idx0-worktree-dotgit-file-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: temp) }
+
+    let paths = try makePaths(root: temp)
+    let repoRoot = temp.appendingPathComponent("repo", isDirectory: true)
+    try FileManager.default.createDirectory(at: repoRoot, withIntermediateDirectories: true)
+
+    let actualGitDir = temp.appendingPathComponent("shared-git-dir", isDirectory: true)
+    let infoDir = actualGitDir.appendingPathComponent("info", isDirectory: true)
+    try FileManager.default.createDirectory(at: infoDir, withIntermediateDirectories: true)
+    let excludeURL = infoDir.appendingPathComponent("exclude", isDirectory: false)
+    try "header\n".write(to: excludeURL, atomically: true, encoding: .utf8)
+    try "gitdir: \(actualGitDir.path)\n".write(
+      to: repoRoot.appendingPathComponent(".git", isDirectory: false),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    let git = MockGitService()
+    let service = WorktreeService(
+      gitService: git,
+      paths: paths,
+      worktreeNameGenerator: { "dotgitfile" }
+    )
+
+    _ = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/dotgit", sessionTitle: "DotGit")
+
+    let exclude = try String(contentsOf: excludeURL, encoding: .utf8)
+    let normalizedLines = exclude
+      .components(separatedBy: .newlines)
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+    XCTAssertEqual(normalizedLines.count(where: { $0 == ".idx0/" }), 1)
+  }
+
+  func testDeleteWorktreeIfCleanRemovesThroughGit() async throws {
+    let temp = FileManager.default.temporaryDirectory
+      .appendingPathComponent("idx0-worktree-delete-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: temp) }
+
+    let paths = try makePaths(root: temp)
+    let git = MockGitService()
+    let service = WorktreeService(gitService: git, paths: paths)
+
+    let repoPath = "/tmp/repo-clean"
+    let worktreePath = temp.appendingPathComponent("wt-clean", isDirectory: true).path
+    try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+
+    git.listedWorktrees = [WorktreeInfo(repoPath: repoPath, worktreePath: worktreePath, branchName: "main")]
+    git.statusOutput = ""
+
+    try await service.deleteWorktreeIfClean(repoPath: repoPath, worktreePath: worktreePath)
+    XCTAssertEqual(git.removedWorktreePaths, [worktreePath])
+  }
+
+  func testDeleteWorktreeIfCleanThrowsWhenDirty() async throws {
+    let temp = FileManager.default.temporaryDirectory
+      .appendingPathComponent("idx0-worktree-dirty-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: temp) }
+
+    let paths = try makePaths(root: temp)
+    let git = MockGitService()
+    let service = WorktreeService(gitService: git, paths: paths)
+
+    let repoPath = "/tmp/repo-dirty"
+    let worktreePath = temp.appendingPathComponent("wt-dirty", isDirectory: true).path
+    try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+
+    git.listedWorktrees = [WorktreeInfo(repoPath: repoPath, worktreePath: worktreePath, branchName: "main")]
+    git.statusOutput = " M changed.swift"
+
+    do {
+      try await service.deleteWorktreeIfClean(repoPath: repoPath, worktreePath: worktreePath)
+      XCTFail("Expected dirty worktree error")
+    } catch let error as WorktreeServiceError {
+      switch error {
+      case .worktreeDirty:
+        break
+      default:
+        XCTFail("Unexpected worktree error: \(error)")
+      }
+    } catch {
+      XCTFail("Unexpected error: \(error)")
     }
+  }
 
-    func testCreateWorktreeAddsIDX0RuleToLocalExcludeIdempotently() async throws {
-        let temp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("idx0-worktree-exclude-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: temp) }
+  private func makePaths(root: URL) throws -> FileSystemPaths {
+    let appSupport = root.appendingPathComponent("AppSupport", isDirectory: true)
+    try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
 
-        let paths = try makePaths(root: temp)
-        let repoRoot = try makeRepoRoot(at: temp, name: "repo")
-        let excludeURL = repoRoot.appendingPathComponent(".git/info/exclude", isDirectory: false)
-        try "existing-rule\n".write(to: excludeURL, atomically: true, encoding: .utf8)
+    return FileSystemPaths(
+      appSupportDirectory: appSupport,
+      sessionsFile: appSupport.appendingPathComponent("sessions.json"),
+      projectsFile: appSupport.appendingPathComponent("projects.json"),
+      inboxFile: appSupport.appendingPathComponent("inbox.json"),
+      settingsFile: appSupport.appendingPathComponent("settings.json"),
+      runDirectory: appSupport.appendingPathComponent("run", isDirectory: true),
+      tempDirectory: appSupport.appendingPathComponent("temp", isDirectory: true),
+      worktreesDirectory: appSupport.appendingPathComponent("worktrees", isDirectory: true)
+    )
+  }
 
-        let git = MockGitService()
-        let service = WorktreeService(
-            gitService: git,
-            paths: paths,
-            worktreeNameGenerator: { "idempotent" }
-        )
-
-        _ = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/one", sessionTitle: "One")
-        _ = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/two", sessionTitle: "Two")
-
-        let exclude = try String(contentsOf: excludeURL, encoding: .utf8)
-        let normalizedLines = exclude
-            .components(separatedBy: .newlines)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        XCTAssertEqual(normalizedLines.filter { $0 == ".idx0/" }.count, 1)
-    }
-
-    func testCreateWorktreeUpdatesExcludeWhenDotGitIsFile() async throws {
-        let temp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("idx0-worktree-dotgit-file-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: temp) }
-
-        let paths = try makePaths(root: temp)
-        let repoRoot = temp.appendingPathComponent("repo", isDirectory: true)
-        try FileManager.default.createDirectory(at: repoRoot, withIntermediateDirectories: true)
-
-        let actualGitDir = temp.appendingPathComponent("shared-git-dir", isDirectory: true)
-        let infoDir = actualGitDir.appendingPathComponent("info", isDirectory: true)
-        try FileManager.default.createDirectory(at: infoDir, withIntermediateDirectories: true)
-        let excludeURL = infoDir.appendingPathComponent("exclude", isDirectory: false)
-        try "header\n".write(to: excludeURL, atomically: true, encoding: .utf8)
-        try "gitdir: \(actualGitDir.path)\n".write(
-            to: repoRoot.appendingPathComponent(".git", isDirectory: false),
-            atomically: true,
-            encoding: .utf8
-        )
-
-        let git = MockGitService()
-        let service = WorktreeService(
-            gitService: git,
-            paths: paths,
-            worktreeNameGenerator: { "dotgitfile" }
-        )
-
-        _ = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/dotgit", sessionTitle: "DotGit")
-
-        let exclude = try String(contentsOf: excludeURL, encoding: .utf8)
-        let normalizedLines = exclude
-            .components(separatedBy: .newlines)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        XCTAssertEqual(normalizedLines.filter { $0 == ".idx0/" }.count, 1)
-    }
-
-    func testDeleteWorktreeIfCleanRemovesThroughGit() async throws {
-        let temp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("idx0-worktree-delete-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: temp) }
-
-        let paths = try makePaths(root: temp)
-        let git = MockGitService()
-        let service = WorktreeService(gitService: git, paths: paths)
-
-        let repoPath = "/tmp/repo-clean"
-        let worktreePath = temp.appendingPathComponent("wt-clean", isDirectory: true).path
-        try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
-
-        git.listedWorktrees = [WorktreeInfo(repoPath: repoPath, worktreePath: worktreePath, branchName: "main")]
-        git.statusOutput = ""
-
-        try await service.deleteWorktreeIfClean(repoPath: repoPath, worktreePath: worktreePath)
-        XCTAssertEqual(git.removedWorktreePaths, [worktreePath])
-    }
-
-    func testDeleteWorktreeIfCleanThrowsWhenDirty() async throws {
-        let temp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("idx0-worktree-dirty-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: temp) }
-
-        let paths = try makePaths(root: temp)
-        let git = MockGitService()
-        let service = WorktreeService(gitService: git, paths: paths)
-
-        let repoPath = "/tmp/repo-dirty"
-        let worktreePath = temp.appendingPathComponent("wt-dirty", isDirectory: true).path
-        try FileManager.default.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
-
-        git.listedWorktrees = [WorktreeInfo(repoPath: repoPath, worktreePath: worktreePath, branchName: "main")]
-        git.statusOutput = " M changed.swift"
-
-        do {
-            try await service.deleteWorktreeIfClean(repoPath: repoPath, worktreePath: worktreePath)
-            XCTFail("Expected dirty worktree error")
-        } catch let error as WorktreeServiceError {
-            switch error {
-            case .worktreeDirty:
-                break
-            default:
-                XCTFail("Unexpected worktree error: \(error)")
-            }
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
-    }
-
-    private func makePaths(root: URL) throws -> FileSystemPaths {
-        let appSupport = root.appendingPathComponent("AppSupport", isDirectory: true)
-        try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
-
-        return FileSystemPaths(
-            appSupportDirectory: appSupport,
-            sessionsFile: appSupport.appendingPathComponent("sessions.json"),
-            projectsFile: appSupport.appendingPathComponent("projects.json"),
-            inboxFile: appSupport.appendingPathComponent("inbox.json"),
-            settingsFile: appSupport.appendingPathComponent("settings.json"),
-            runDirectory: appSupport.appendingPathComponent("run", isDirectory: true),
-            tempDirectory: appSupport.appendingPathComponent("temp", isDirectory: true),
-            worktreesDirectory: appSupport.appendingPathComponent("worktrees", isDirectory: true)
-        )
-    }
-
-    private func makeRepoRoot(at root: URL, name: String) throws -> URL {
-        let repoRoot = root.appendingPathComponent(name, isDirectory: true)
-        let infoDir = repoRoot
-            .appendingPathComponent(".git", isDirectory: true)
-            .appendingPathComponent("info", isDirectory: true)
-        try FileManager.default.createDirectory(at: infoDir, withIntermediateDirectories: true)
-        return repoRoot
-    }
+  private func makeRepoRoot(at root: URL, name: String) throws -> URL {
+    let repoRoot = root.appendingPathComponent(name, isDirectory: true)
+    let infoDir = repoRoot
+      .appendingPathComponent(".git", isDirectory: true)
+      .appendingPathComponent("info", isDirectory: true)
+    try FileManager.default.createDirectory(at: infoDir, withIntermediateDirectories: true)
+    return repoRoot
+  }
 }
 
 private final class MockGitService: GitServiceProtocol {
-    var createdWorktreePaths: [String] = []
-    var removedWorktreePaths: [String] = []
-    var listedWorktrees: [WorktreeInfo] = []
-    var statusOutput = ""
+  var createdWorktreePaths: [String] = []
+  var removedWorktreePaths: [String] = []
+  var listedWorktrees: [WorktreeInfo] = []
+  var statusOutput = ""
 
-    func repoInfo(for path: String) async throws -> GitRepoInfo {
-        GitRepoInfo(topLevelPath: path, currentBranch: "main", repoName: "repo")
-    }
+  func repoInfo(for path: String) async throws -> GitRepoInfo {
+    GitRepoInfo(topLevelPath: path, currentBranch: "main", repoName: "repo")
+  }
 
-    func currentBranch(repoPath: String) async throws -> String? {
-        _ = repoPath
-        return "main"
-    }
+  func currentBranch(repoPath: String) async throws -> String? {
+    _ = repoPath
+    return "main"
+  }
 
-    func currentCommitSHA(repoPath: String) async throws -> String? {
-        _ = repoPath
-        return String(repeating: "a", count: 40)
-    }
+  func currentCommitSHA(repoPath: String) async throws -> String? {
+    _ = repoPath
+    return String(repeating: "a", count: 40)
+  }
 
-    func localBranches(repoPath: String) async throws -> [String] {
-        _ = repoPath
-        return ["main"]
-    }
+  func localBranches(repoPath: String) async throws -> [String] {
+    _ = repoPath
+    return ["main"]
+  }
 
-    func listWorktrees(repoPath: String) async throws -> [WorktreeInfo] {
-        _ = repoPath
-        return listedWorktrees
-    }
+  func listWorktrees(repoPath: String) async throws -> [WorktreeInfo] {
+    _ = repoPath
+    return listedWorktrees
+  }
 
-    func createWorktree(repoPath: String, branchName: String, worktreePath: String) async throws -> WorktreeInfo {
-        _ = repoPath
-        _ = branchName
-        createdWorktreePaths.append(worktreePath)
-        return WorktreeInfo(repoPath: repoPath, worktreePath: worktreePath, branchName: branchName)
-    }
+  func createWorktree(repoPath: String, branchName: String, worktreePath: String) async throws -> WorktreeInfo {
+    _ = repoPath
+    _ = branchName
+    createdWorktreePaths.append(worktreePath)
+    return WorktreeInfo(repoPath: repoPath, worktreePath: worktreePath, branchName: branchName)
+  }
 
-    func statusPorcelain(path: String) async throws -> String {
-        _ = path
-        return statusOutput
-    }
+  func statusPorcelain(path: String) async throws -> String {
+    _ = path
+    return statusOutput
+  }
 
-    func removeWorktree(repoPath: String, worktreePath: String) async throws {
-        _ = repoPath
-        removedWorktreePaths.append(worktreePath)
-    }
+  func removeWorktree(repoPath: String, worktreePath: String) async throws {
+    _ = repoPath
+    removedWorktreePaths.append(worktreePath)
+  }
 
-    func diffNameStatus(path: String) async throws -> [ChangedFileSummary] {
-        _ = path
-        return []
-    }
+  func diffNameStatus(path: String) async throws -> [ChangedFileSummary] {
+    _ = path
+    return []
+  }
 
-    func diffNameStatus(path: String, between leftRef: String, and rightRef: String) async throws -> [ChangedFileSummary] {
-        _ = path
-        _ = leftRef
-        _ = rightRef
-        return []
-    }
+  func diffNameStatus(path: String, between leftRef: String, and rightRef: String) async throws -> [ChangedFileSummary] {
+    _ = path
+    _ = leftRef
+    _ = rightRef
+    return []
+  }
 
-    func diffStat(path: String) async throws -> DiffStat? {
-        _ = path
-        return DiffStat(filesChanged: 0, additions: 0, deletions: 0)
-    }
+  func diffStat(path: String) async throws -> DiffStat? {
+    _ = path
+    return DiffStat(filesChanged: 0, additions: 0, deletions: 0)
+  }
 
-    func diffStat(path: String, between leftRef: String, and rightRef: String) async throws -> DiffStat? {
-        _ = path
-        _ = leftRef
-        _ = rightRef
-        return DiffStat(filesChanged: 0, additions: 0, deletions: 0)
-    }
+  func diffStat(path: String, between leftRef: String, and rightRef: String) async throws -> DiffStat? {
+    _ = path
+    _ = leftRef
+    _ = rightRef
+    return DiffStat(filesChanged: 0, additions: 0, deletions: 0)
+  }
 }

--- a/idx0Tests/WorktreePathGenerationTests.swift
+++ b/idx0Tests/WorktreePathGenerationTests.swift
@@ -3,26 +3,104 @@ import XCTest
 @testable import idx0
 
 final class WorktreePathGenerationTests: XCTestCase {
-    func testCreateWorktreeAppendsCollisionSuffix() async throws {
+    func testCreateWorktreeUsesWorkspaceLocalPathAndAppendsCollisionSuffix() async throws {
         let temp = FileManager.default.temporaryDirectory
             .appendingPathComponent("idx0-worktree-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: temp) }
 
         let paths = try makePaths(root: temp)
+        let repoRoot = try makeRepoRoot(at: temp, name: "repo")
         let git = MockGitService()
-        let service = WorktreeService(gitService: git, paths: paths)
+        let service = WorktreeService(
+            gitService: git,
+            paths: paths,
+            worktreeNameGenerator: { "collision-name" }
+        )
 
-        let first = try await service.createWorktree(repoPath: "/tmp/repo", branchName: "idx0/fix", sessionTitle: "Fix")
+        let first = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/fix", sessionTitle: "Fix")
 
         try FileManager.default.createDirectory(atPath: first.worktreePath, withIntermediateDirectories: true)
 
-        _ = try await service.createWorktree(repoPath: "/tmp/repo", branchName: "idx0/fix", sessionTitle: "Fix")
+        let second = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/fix-2", sessionTitle: "Fix")
 
         let createdPaths = git.createdWorktreePaths
         XCTAssertEqual(createdPaths.count, 2)
-        XCTAssertTrue(createdPaths[0].hasSuffix("/idx0-fix"))
-        XCTAssertTrue(createdPaths[1].hasSuffix("/idx0-fix-2"))
+        XCTAssertEqual(URL(fileURLWithPath: first.worktreePath).lastPathComponent, "wt-collisionnam")
+        XCTAssertEqual(URL(fileURLWithPath: second.worktreePath).lastPathComponent, "wt-collisionnam-2")
+
+        let expectedPrefix = repoRoot
+            .appendingPathComponent(".idx0/worktrees", isDirectory: true)
+            .path + "/"
+        XCTAssertTrue(first.worktreePath.hasPrefix(expectedPrefix))
+        XCTAssertTrue(second.worktreePath.hasPrefix(expectedPrefix))
+    }
+
+    func testCreateWorktreeAddsIDX0RuleToLocalExcludeIdempotently() async throws {
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("idx0-worktree-exclude-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let paths = try makePaths(root: temp)
+        let repoRoot = try makeRepoRoot(at: temp, name: "repo")
+        let excludeURL = repoRoot.appendingPathComponent(".git/info/exclude", isDirectory: false)
+        try "existing-rule\n".write(to: excludeURL, atomically: true, encoding: .utf8)
+
+        let git = MockGitService()
+        let service = WorktreeService(
+            gitService: git,
+            paths: paths,
+            worktreeNameGenerator: { "idempotent" }
+        )
+
+        _ = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/one", sessionTitle: "One")
+        _ = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/two", sessionTitle: "Two")
+
+        let exclude = try String(contentsOf: excludeURL, encoding: .utf8)
+        let normalizedLines = exclude
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        XCTAssertEqual(normalizedLines.filter { $0 == ".idx0/" }.count, 1)
+    }
+
+    func testCreateWorktreeUpdatesExcludeWhenDotGitIsFile() async throws {
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("idx0-worktree-dotgit-file-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let paths = try makePaths(root: temp)
+        let repoRoot = temp.appendingPathComponent("repo", isDirectory: true)
+        try FileManager.default.createDirectory(at: repoRoot, withIntermediateDirectories: true)
+
+        let actualGitDir = temp.appendingPathComponent("shared-git-dir", isDirectory: true)
+        let infoDir = actualGitDir.appendingPathComponent("info", isDirectory: true)
+        try FileManager.default.createDirectory(at: infoDir, withIntermediateDirectories: true)
+        let excludeURL = infoDir.appendingPathComponent("exclude", isDirectory: false)
+        try "header\n".write(to: excludeURL, atomically: true, encoding: .utf8)
+        try "gitdir: \(actualGitDir.path)\n".write(
+            to: repoRoot.appendingPathComponent(".git", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let git = MockGitService()
+        let service = WorktreeService(
+            gitService: git,
+            paths: paths,
+            worktreeNameGenerator: { "dotgitfile" }
+        )
+
+        _ = try await service.createWorktree(repoPath: repoRoot.path, branchName: "idx0/dotgit", sessionTitle: "DotGit")
+
+        let exclude = try String(contentsOf: excludeURL, encoding: .utf8)
+        let normalizedLines = exclude
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        XCTAssertEqual(normalizedLines.filter { $0 == ".idx0/" }.count, 1)
     }
 
     func testDeleteWorktreeIfCleanRemovesThroughGit() async throws {
@@ -92,6 +170,15 @@ final class WorktreePathGenerationTests: XCTestCase {
             tempDirectory: appSupport.appendingPathComponent("temp", isDirectory: true),
             worktreesDirectory: appSupport.appendingPathComponent("worktrees", isDirectory: true)
         )
+    }
+
+    private func makeRepoRoot(at root: URL, name: String) throws -> URL {
+        let repoRoot = root.appendingPathComponent(name, isDirectory: true)
+        let infoDir = repoRoot
+            .appendingPathComponent(".git", isDirectory: true)
+            .appendingPathComponent("info", isDirectory: true)
+        try FileManager.default.createDirectory(at: infoDir, withIntermediateDirectories: true)
+        return repoRoot
     }
 }
 


### PR DESCRIPTION
## Summary

- Store newly created worktrees under each repo at `<repo>/.idx0/worktrees/` instead of app support.
- Use random worktree directory names (`wt-<token>`) with collision-safe suffixing.
- Default repo-backed session creation to always create a worktree, with an opt-out settings toggle.
- Keep repo status clean by idempotently adding `.idx0/` to local git exclude.

## Details

- `WorktreeService` now creates worktree paths inside repo-local `.idx0/worktrees` and resolves `.git` directory or `.git` file (`gitdir:`) when updating local exclude.
- `SessionService.createSession` now auto-creates worktrees for repo-backed sessions when `defaultCreateWorktreeForRepoSessions` is enabled (default true), while still allowing explicit attach/create flows.
- New Session UI reflects enforced behavior by disabling the worktree toggle when the setting is enabled for a git repo and shows guidance to disable in Settings.
- Session settings copy was updated to match the new behavior.
- Integration and unit tests were expanded for random path generation, collision handling, `.idx0/` exclude idempotence, and default session behavior.

## Related Issues

- Related to workspace-local random worktree rollout.

## How to Validate

1. Run focused tests:
   - `xcodebuild -project idx0.xcodeproj -scheme idx0 -destination 'platform=macOS' test -only-testing:idx0Tests/WorktreePathGenerationTests -only-testing:idx0Tests/SessionServiceIntegrationTests`
2. In app Settings > Sessions, keep "Create Worktree By Default" enabled.
3. Create a session with a git repo folder and verify session is worktree-backed under `<repo>/.idx0/worktrees/wt-*`.
4. In that repo, run `git status --short` and verify `.idx0/` is not shown as untracked.
5. Disable "Create Worktree By Default" and create another repo session; verify non-worktree branch mode is available and session can be created without a worktree.

## Pre-Merge Checklist

- [x] `lint-docs` check is green
- [x] `tests` check is green
- [x] `maintainability` result reviewed (phase 1 report-only)
- [x] Added/updated tests (if needed)
- [ ] Updated relevant documentation and README (if needed)
- [ ] Noted breaking changes (if any)
- [x] Tested on macOS

